### PR TITLE
Move the Why-not-just-use section below How it works

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1557,33 +1557,6 @@ spec:
   </div>
 </section>
 
-<!-- ══ instead of ════════════════════════════════════════════ -->
-<section class="section-alt" id="instead">
-  <div class="wrap">
-    <div class="section-head">
-      <p class="eyebrow">Why not just use ...</p><hr class="rule">
-    </div>
-
-    <div class="uses uses-2">
-      <div class="use-col">
-        <ul>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-mail"/></svg>Quicker to set up than an <b>SMTP relay</b></li>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-split"/></svg>Your important notifications in one place, without cluttering your <b>email inbox</b></li>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-air"/></svg>Lighter than running <b>Slack</b></li>
-        </ul>
-      </div>
-      <div class="use-col">
-        <ul>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-agent"/></svg>No bot to register, unlike <b>Telegram</b></li>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-format"/></svg>Custom formatting, unlike <b>SMS</b></li>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-lock"/></svg>Encrypted, unlike <b>Ntfy</b></li>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-money"/></svg>Free, unlike <b>Pushover</b></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</section>
-
 <!-- ══ how it works ══════════════════════════════════════════ -->
 <section class="section-alt" id="how">
   <div class="wrap">
@@ -1634,6 +1607,33 @@ spec:
         <svg class="ico" aria-hidden="true" focusable="false"><use href="#i-branch"/></svg>
         <p>The app, the API and the crypto are on
            <a href="https://github.com/notifi-it/notifi" class="src">GitHub</a>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ══ instead of ════════════════════════════════════════════ -->
+<section class="section-alt" id="instead">
+  <div class="wrap">
+    <div class="section-head">
+      <p class="eyebrow">Why not just use ...</p><hr class="rule">
+    </div>
+
+    <div class="uses uses-2">
+      <div class="use-col">
+        <ul>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-mail"/></svg>Quicker to set up than an <b>SMTP relay</b></li>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-split"/></svg>Your important notifications in one place, without cluttering your <b>email inbox</b></li>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-air"/></svg>Lighter than running <b>Slack</b></li>
+        </ul>
+      </div>
+      <div class="use-col">
+        <ul>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-agent"/></svg>No bot to register, unlike <b>Telegram</b></li>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-format"/></svg>Custom formatting, unlike <b>SMS</b></li>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-lock"/></svg>Encrypted, unlike <b>Ntfy</b></li>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-money"/></svg>Free, unlike <b>Pushover</b></li>
+        </ul>
       </div>
     </div>
   </div>

--- a/apps/api/public/index.md
+++ b/apps/api/public/index.md
@@ -25,16 +25,6 @@ own send keys, for marketing, and for anything where a missed notification
 causes harm: a key delivers only to the device that made it, and delivery is
 best-effort.
 
-## Why not just use ...
-
-- Quicker to set up than an **SMTP relay**
-- Your important notifications in one place, without cluttering your **email inbox**
-- Lighter than running **Slack**
-- No bot to register, unlike **Telegram**
-- Custom formatting, unlike **SMS**
-- Encrypted, unlike **Ntfy**
-- Free, unlike **Pushover**
-
 ## Start
 
 1. Install the app: [iPhone and iPad](https://apps.apple.com/app/id1563961135)
@@ -71,6 +61,16 @@ parameter.
 
 The full reference is at [notifi.it/docs](https://notifi.it/docs), machine-readable
 at [notifi.it/openapi.json](https://notifi.it/openapi.json).
+
+## Why not just use ...
+
+- Quicker to set up than an **SMTP relay**
+- Your important notifications in one place, without cluttering your **email inbox**
+- Lighter than running **Slack**
+- No bot to register, unlike **Telegram**
+- Custom formatting, unlike **SMS**
+- Encrypted, unlike **Ntfy**
+- Free, unlike **Pushover**
 
 ## What it costs
 


### PR DESCRIPTION
The comparison list lands better once the reader knows how the product works, so the landing page now runs uses, how it works, why not just use, download. The hand-written index.md mirrors the order by moving the section after The API. Both sections sit outside the gen markers and `make check-site-html` passes.