### PR TITLE
Merge the Send section into the API section

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1139,6 +1139,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
     <p class="meta" style="margin-bottom:26px">
       JSON or form-encoded. Authenticate with <code>Authorization: Bearer &lt;key&gt;</code>,
       or pass <code>key</code> as a parameter.
+      The full reference is at <a href="/docs" class="src">notifi.it/docs</a>.
     </p>
 <!-- /gen:endpoint -->
 
@@ -1191,26 +1192,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
         </tbody>
       </table>
     </div>
-
-    <!-- Two hairline rows for four facts read as a section; the facts are the
-         same size as the sentence they now sit in. -->
-<!-- gen:apinote -->
-    <p class="meta" style="margin-top:22px">
-      The full reference is at <a href="/docs" class="src">notifi.it/docs</a>.
-    </p>
-<!-- /gen:apinote -->
-  </div>
-</section>
-
-<!-- ══ languages ═════════════════════════════════════════════ -->
-<section class="section-alt" id="send">
-  <div class="wrap">
-    <div class="section-head">
-      <p class="eyebrow">Send</p><hr class="rule">
-    </div>
-    <p class="lede" style="margin-top:14px;margin-bottom:26px">
-      Copy a snippet below and put your key in it. Anything that can make an HTTP request can send a notification to your device.
-    </p>
 
     <!-- Seven, and they fit on one line. Twelve wrapped to three rows of chips,
          which is a lot of furniture above a block only one of them can fill —

--- a/packages/apidoc/src/index.ts
+++ b/packages/apidoc/src/index.ts
@@ -8,7 +8,6 @@ export {
   landingTabs,
   landingPanels,
   landingEndpoint,
-  landingNote,
   highlight,
   terminal,
   terminalGroup,

--- a/packages/apidoc/src/landing.ts
+++ b/packages/apidoc/src/landing.ts
@@ -100,11 +100,6 @@ export function landingEndpoint(): string {
     <p class="meta" style="margin-bottom:26px">
       JSON or form-encoded. Authenticate with <code>Authorization: Bearer &lt;key&gt;</code>,
       or pass <code>key</code> as a parameter.
-    </p>`;
-}
-
-export function landingNote(): string {
-  return `    <p class="meta" style="margin-top:22px">
       The full reference is at <a href="/docs" class="src">notifi.it/docs</a>.
     </p>`;
 }

--- a/packages/site/scripts/gen-site.ts
+++ b/packages/site/scripts/gen-site.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'node:url';
 import {
   docsBody,
   landingEndpoint,
-  landingNote,
   landingPanels,
   landingRows,
   landingTabs,
@@ -153,7 +152,6 @@ function landing(): string {
   html = splice(html, 'footer', footer({ path: '/' } as Meta));
   html = splice(html, 'endpoint', landingEndpoint());
   html = splice(html, 'params', landingRows());
-  html = splice(html, 'apinote', landingNote());
   html = splice(html, 'tabs', landingTabs());
   html = splice(html, 'panels', landingPanels());
   html = splice(html, 'termcss', terminalCss.trimEnd(), 'css');


### PR DESCRIPTION
The landing page told the API story twice: an API section with the endpoint and parameter table, then a separate Send section holding the code snippets. The Send eyebrow and its "Copy a snippet below" lede are gone, and the language tabs plus code terminal now sit directly under the parameter table in the API section. The full-reference line moves up under the GET-or-POST endpoint header, folded into the existing meta paragraph, so the unused landingNote generator and apinote splice marker are deleted.