### PR TITLE
Migrate markdown rendering from MarkdownUI to Textual

### DIFF
--- a/apps/app/Shared/Support/Markdown.swift
+++ b/apps/app/Shared/Support/Markdown.swift
@@ -1,5 +1,5 @@
-import MarkdownUI
 import SwiftUI
+import Textual
 
 struct MarkdownText: View {
     let source: String
@@ -13,28 +13,205 @@ struct MarkdownText: View {
                 markdown
             } else {
                 markdown
-                    .markdownImageProvider(BlockedImageProvider())
-                    .markdownInlineImageProvider(BlockedInlineImageProvider())
+                    .textual.imageAttachmentLoader(BlockedImageLoader())
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .textSelection(.enabled)
+        .textual.textSelection(.enabled)
         .environment(\.openURL, OpenURLAction { url in
             LinkPolicy.allows(url, anyScheme: allowAnyScheme) ? .systemAction : .discarded
         })
     }
 
     private var markdown: some View {
-        Markdown(source).markdownTheme(.geist(critical: critical))
+        StructuredText(markdown: source)
+            .font(.custom("Karla", size: 15))
+            .foregroundStyle(Theme.muted)
+            .textual.structuredTextStyle(GeistStructuredStyle(critical: critical))
     }
 }
 
-private struct RemoteImageBlocked: Error {}
+private struct GeistStructuredStyle: StructuredText.Style {
+    let critical: Bool
 
-private struct BlockedImageProvider: ImageProvider {
-    func makeImage(url: URL?) -> some View {
+    var inlineStyle: InlineStyle {
+        InlineStyle()
+            .code(.font(.custom("Recursive Mono", size: 13)),
+                  .foregroundColor(Theme.fg),
+                  .backgroundColor(Theme.surface))
+            .strong(.fontWeight(.semibold), .foregroundColor(critical ? Theme.brandDim : Theme.fg))
+            .link(.foregroundColor(Theme.fg), .underlineStyle(.single))
+            .strikethrough(.strikethroughStyle(Text.LineStyle(pattern: .solid, color: Theme.brand)),
+                           .foregroundColor(Theme.brandDim))
+    }
+
+    var headingStyle: GeistHeadingStyle { GeistHeadingStyle() }
+    var paragraphStyle: GeistParagraphStyle { GeistParagraphStyle() }
+    var blockQuoteStyle: GeistBlockQuoteStyle { GeistBlockQuoteStyle() }
+    var codeBlockStyle: GeistCodeBlockStyle { GeistCodeBlockStyle() }
+    var listItemStyle: StructuredText.DefaultListItemStyle { .default }
+    var unorderedListMarker: StructuredText.SymbolListMarker { .disc }
+    var orderedListMarker: StructuredText.DecimalListMarker { .decimal }
+    var tableStyle: GeistTableStyle { GeistTableStyle() }
+    var tableCellStyle: GeistTableCellStyle { GeistTableCellStyle() }
+    var thematicBreakStyle: GeistThematicBreakStyle { GeistThematicBreakStyle() }
+}
+
+private struct GeistHeadingStyle: StructuredText.HeadingStyle {
+    private static let sizes: [CGFloat] = [24, 21, 19, 18, 17, 16]
+    private static let weights: [Font.Weight] = [.bold, .semibold, .semibold, .semibold, .medium, .medium]
+    private static let tops: [CGFloat] = [24, 22, 20, 18, 16, 16]
+    private static let bottoms: [CGFloat] = [8, 6, 6, 4, 4, 4]
+
+    func makeBody(configuration: Configuration) -> some View {
+        let level = min(max(configuration.headingLevel, 1), 6)
+
+        configuration.label
+            .tracking(0.5)
+            .font(.custom("Recursive Mono", size: Self.sizes[level - 1]))
+            .fontWeight(Self.weights[level - 1])
+            .foregroundStyle(Theme.fg)
+            .textual.blockSpacing(StructuredText.BlockSpacing(top: Self.tops[level - 1],
+                                                              bottom: Self.bottoms[level - 1]))
+    }
+}
+
+private struct GeistParagraphStyle: StructuredText.ParagraphStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .fixedSize(horizontal: false, vertical: true)
+            .textual.lineSpacing(.fontScaled(0.2))
+            .textual.blockSpacing(.fontScaled(top: 0.8))
+    }
+}
+
+private struct GeistBlockQuoteStyle: StructuredText.BlockQuoteStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Rectangle().fill(Theme.controlBorder).frame(width: 2)
+            configuration.label
+                .foregroundStyle(Theme.dim)
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .textual.blockSpacing(.fontScaled(top: 0.8))
+    }
+}
+
+private struct GeistCodeBlockStyle: StructuredText.CodeBlockStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Overflow {
+            configuration.label
+                .textual.lineSpacing(.fontScaled(0.2))
+                .font(.custom("Recursive Mono", size: 13))
+                .foregroundStyle(Theme.fg)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.vertical, 12)
+                .padding(.leading, 12)
+                .padding(.trailing, 48)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface)
+        .overlay(alignment: .trailing) {
+            LinearGradient(colors: [Theme.surface.opacity(0), Theme.surface],
+                           startPoint: .leading, endPoint: .trailing)
+                .frame(width: 32)
+                .allowsHitTesting(false)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Theme.radius))
+        .overlay(RoundedRectangle(cornerRadius: Theme.radius).stroke(Theme.chip, lineWidth: 1))
+        .overlay(alignment: .topTrailing) {
+            CodeCopyButton(codeBlock: configuration.codeBlock)
+        }
+        .textual.blockSpacing(.fontScaled(top: 0.8, bottom: 0.8))
+    }
+}
+
+private struct CodeCopyButton: View {
+    let codeBlock: StructuredText.CodeBlockProxy
+    @State private var copied = false
+
+    var body: some View {
+        Button {
+            codeBlock.copyToPasteboard()
+            copied = true
+            Task {
+                try? await Task.sleep(for: .seconds(1.5))
+                copied = false
+            }
+        } label: {
+            SwiftUI.Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(copied ? Theme.fg : Theme.dim)
+                .padding(6)
+                .background(Theme.surface, in: RoundedRectangle(cornerRadius: Theme.radius))
+                .overlay(RoundedRectangle(cornerRadius: Theme.radius).stroke(Theme.chip, lineWidth: 1))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(6)
+        .accessibilityLabel(copied ? Copy.Common.copied : Copy.Common.copy)
+    }
+}
+
+private struct GeistTableStyle: StructuredText.TableStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Overflow { state in
+            configuration.label
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(minWidth: state.containerWidth,
+                       maxWidth: state.containerWidth.map { $0 * 1.5 },
+                       alignment: .leading)
+                .textual.tableOverlay { layout in
+                    Canvas { context, _ in
+                        for divider in layout.dividers() {
+                            context.fill(Path(divider), with: .color(Theme.chip))
+                        }
+                    }
+                }
+                .padding(1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Theme.radius))
+        .overlay(RoundedRectangle(cornerRadius: Theme.radius).stroke(Theme.chip, lineWidth: 1))
+        .textual.tableCellSpacing(horizontal: 1, vertical: 1)
+        .textual.blockSpacing(.fontScaled(top: 0.8, bottom: 0.8))
+    }
+}
+
+private struct GeistTableCellStyle: StructuredText.TableCellStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .fontWeight(configuration.row == 0 ? .semibold : .regular)
+            .foregroundStyle(configuration.row == 0 ? Theme.fg : Theme.muted)
+            .textual.lineSpacing(.fontScaled(0.2))
+            .padding(.vertical, 6)
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct GeistThematicBreakStyle: StructuredText.ThematicBreakStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Hairline()
+            .textual.blockSpacing(.fontScaled(top: 1, bottom: 1))
+    }
+}
+
+private struct BlockedImageLoader: AttachmentLoader {
+    func attachment(
+        for url: URL,
+        text: String,
+        environment: ColorEnvironmentValues
+    ) async throws -> BlockedImageAttachment {
+        BlockedImageAttachment()
+    }
+}
+
+private struct BlockedImageAttachment: Attachment {
+    var description: String { Copy.Message.imageHidden }
+
+    var body: some View {
         HStack(spacing: 7) {
-            Image(systemName: "photo")
+            SwiftUI.Image(systemName: "photo")
                 .font(.system(size: 12, weight: .medium))
             Text(Copy.Message.imageHidden)
                 .font(.inco(.footnote))
@@ -46,100 +223,8 @@ private struct BlockedImageProvider: ImageProvider {
         .background(Theme.surface, in: RoundedRectangle(cornerRadius: Theme.radius))
         .overlay(RoundedRectangle(cornerRadius: Theme.radius).stroke(Theme.chip, lineWidth: 1))
     }
-}
 
-private struct BlockedInlineImageProvider: InlineImageProvider {
-    func image(with url: URL, label: String) async throws -> Image {
-        throw RemoteImageBlocked()
-    }
-}
-
-extension MarkdownUI.Theme {
-    @MainActor
-    static func geist(critical: Bool = false) -> MarkdownUI.Theme {
-        MarkdownUI.Theme()
-        .text {
-            FontFamily(.custom("Karla"))
-            FontSize(15)
-            ForegroundColor(Theme.muted)
-        }
-        .strong {
-            FontWeight(.semibold)
-            ForegroundColor(critical ? Theme.brandDim : Theme.fg)
-        }
-        .code {
-            FontFamily(.custom("Recursive Mono"))
-            FontSize(15)
-            ForegroundColor(Theme.fg)
-        }
-        .link {
-            ForegroundColor(Theme.fg)
-            UnderlineStyle(.single)
-        }
-        .heading1 { bandHeading($0) }
-        .heading2 { bandHeading($0) }
-        .heading3 { bandHeading($0) }
-        .paragraph { configuration in
-            configuration.label
-                .fixedSize(horizontal: false, vertical: true)
-                .relativeLineSpacing(.em(0.2))
-                .markdownMargin(top: .em(0.8))
-        }
-        .blockquote { configuration in
-            HStack(alignment: .top, spacing: 10) {
-                Rectangle().fill(Theme.controlBorder).frame(width: 2)
-                configuration.label
-                    .markdownTextStyle { ForegroundColor(Theme.dim) }
-            }
-            .fixedSize(horizontal: false, vertical: true)
-            .markdownMargin(top: .em(0.8))
-        }
-        .codeBlock { configuration in
-            ScrollView(.horizontal, showsIndicators: false) {
-                configuration.label
-                    .relativeLineSpacing(.em(0.2))
-                    .markdownTextStyle {
-                        FontFamily(.custom("Recursive Mono"))
-                        FontSize(13)
-                        ForegroundColor(Theme.fg)
-                    }
-                    .padding(12)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Theme.surface)
-            .overlay(alignment: .trailing) {
-                LinearGradient(colors: [Theme.surface.opacity(0), Theme.surface],
-                               startPoint: .leading, endPoint: .trailing)
-                    .frame(width: 32)
-                    .allowsHitTesting(false)
-            }
-            .clipShape(RoundedRectangle(cornerRadius: Theme.radius))
-            .overlay(RoundedRectangle(cornerRadius: Theme.radius).stroke(Theme.chip, lineWidth: 1))
-            .markdownMargin(top: .em(0.8), bottom: .em(0.8))
-        }
-        .listItem { configuration in
-            configuration.label
-                .markdownMargin(top: .em(0.3))
-        }
-        .thematicBreak {
-            Hairline()
-                .markdownMargin(top: .em(1), bottom: .em(1))
-        }
-    }
-    @MainActor
-    private static func bandHeading(_ configuration: BlockConfiguration) -> some View {
-        HStack(spacing: 10) {
-            configuration.label
-                .textCase(.uppercase)
-                .tracking(1.4)
-                .markdownTextStyle {
-                    FontFamily(.custom("Recursive Mono"))
-                    FontSize(11)
-                    FontWeight(.semibold)
-                    ForegroundColor(Theme.fg)
-                }
-            Hairline()
-        }
-        .markdownMargin(top: 20, bottom: 6)
+    func sizeThatFits(_ proposal: ProposedViewSize, in environment: TextEnvironmentValues) -> CGSize {
+        CGSize(width: proposal.width ?? 260, height: 40)
     }
 }

--- a/apps/app/project.yml
+++ b/apps/app/project.yml
@@ -3,8 +3,8 @@ name: notifi
 options:
   bundleIdPrefix: it.notifi
   deploymentTarget:
-    iOS: "17.0"
-    macOS: "14.0"
+    iOS: "18.0"
+    macOS: "15.0"
   createIntermediateGroups: true
   groupSortPosition: top
   # Localizable.xcstrings carrying a language is not enough on its own: Xcode
@@ -62,9 +62,9 @@ packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     exactVersion: "2.9.5"
-  MarkdownUI:
-    url: https://github.com/gonzalezreal/swift-markdown-ui
-    from: "2.4.0"
+  Textual:
+    url: https://github.com/gonzalezreal/textual
+    exactVersion: "0.5.0"
 
 targets:
   notifi-iOS:
@@ -92,7 +92,7 @@ targets:
           CODE_SIGN_ENTITLEMENTS: Support/Entitlements/notifi-iOS-Release.entitlements
     dependencies:
       - target: NotificationService-iOS
-      - package: MarkdownUI
+      - package: Textual
 
   notifi-macOS:
     type: application
@@ -114,7 +114,7 @@ targets:
     dependencies:
       - target: NotificationService-macOS
       - package: Sparkle
-      - package: MarkdownUI
+      - package: Textual
 
   NotificationService-iOS:
     type: app-extension


### PR DESCRIPTION
Swaps swift-markdown-ui 2.4.0 (now in maintenance mode) for its successor Textual 0.5.0 and rebuilds the Geist theme on its Style API, raising the deployment targets to iOS 18 / macOS 15. Markdown bodies gain full-width themed tables, a scaled mono heading ramp without hairlines, chipped inline code, red strikethrough, a copy chip on code blocks, and a blocked-image chip that respects the Load images automatically setting. Foundation's parser has no task-list intent, so `- [x]` renders as literal text — an accepted trade-off. Verified on the Simulator: both schemes build, copy lands on the pasteboard, and the image chip appears with the setting off. Screenshots to follow via the web UI, as this CLI cannot upload images.