### PR TITLE
site: jump straight to in-page anchors

### DIFF
--- a/apps/api/public/404.html
+++ b/apps/api/public/404.html
@@ -88,7 +88,7 @@
 *{box-sizing:border-box;margin:0}
 /* scroll-padding-top clears the 60px sticky header, which would otherwise sit
    on top of whatever an in-page anchor just jumped to. */
-html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px;scroll-behavior:smooth}
+html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px}
 body{
   background:var(--bg);color:var(--fg);
   font-family:var(--sans);font-size:16px;line-height:1.6;
@@ -217,8 +217,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 .foot a:hover{color:var(--fg)}
 .foot .meta{margin-left:auto}
 @media(max-width:620px){.foot .meta{margin-left:0;width:100%}}
-
-@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
 /* The 404 page only. Appended after the shared tokens, so nothing here
    has to out-specify them by accident. */
 :root{

--- a/apps/api/public/docs.html
+++ b/apps/api/public/docs.html
@@ -153,7 +153,7 @@
 *{box-sizing:border-box;margin:0}
 /* scroll-padding-top clears the 60px sticky header, which would otherwise sit
    on top of whatever an in-page anchor just jumped to. */
-html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px;scroll-behavior:smooth}
+html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px}
 body{
   background:var(--bg);color:var(--fg);
   font-family:var(--sans);font-size:16px;line-height:1.6;
@@ -282,8 +282,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 .foot a:hover{color:var(--fg)}
 .foot .meta{margin-left:auto}
 @media(max-width:620px){.foot .meta{margin-left:0;width:100%}}
-
-@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
 
 .doc.api p.meta a{color:var(--muted);text-decoration:none}
 .doc.api p.meta a:hover{color:var(--fg)}

--- a/apps/api/public/faq.html
+++ b/apps/api/public/faq.html
@@ -86,7 +86,7 @@
 *{box-sizing:border-box;margin:0}
 /* scroll-padding-top clears the 60px sticky header, which would otherwise sit
    on top of whatever an in-page anchor just jumped to. */
-html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px;scroll-behavior:smooth}
+html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px}
 body{
   background:var(--bg);color:var(--fg);
   font-family:var(--sans);font-size:16px;line-height:1.6;
@@ -215,8 +215,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 .foot a:hover{color:var(--fg)}
 .foot .meta{margin-left:auto}
 @media(max-width:620px){.foot .meta{margin-left:0;width:100%}}
-
-@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
 </style>
 </head>
 <body>

--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -116,7 +116,7 @@
 *{box-sizing:border-box;margin:0}
 /* scroll-padding-top clears the 60px fixed header, which is docked and in the
    way whenever an in-page anchor is followed from below the hero. */
-html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px;scroll-behavior:smooth}
+html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px}
 body{
   background:var(--bg);color:var(--fg);
   font-family:var(--sans);font-size:16px;line-height:1.6;
@@ -950,7 +950,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
    outright turned each of these into a hard cut, which is the jarring change the
    motion was added to prevent. So: nothing moves or resizes, and the fades stay. */
 @media(prefers-reduced-motion:reduce){
-  html{scroll-behavior:auto}
   .btn:active{transform:none}
 }
 </style>

--- a/apps/api/public/privacy.html
+++ b/apps/api/public/privacy.html
@@ -86,7 +86,7 @@
 *{box-sizing:border-box;margin:0}
 /* scroll-padding-top clears the 60px sticky header, which would otherwise sit
    on top of whatever an in-page anchor just jumped to. */
-html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px;scroll-behavior:smooth}
+html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px}
 body{
   background:var(--bg);color:var(--fg);
   font-family:var(--sans);font-size:16px;line-height:1.6;
@@ -215,8 +215,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 .foot a:hover{color:var(--fg)}
 .foot .meta{margin-left:auto}
 @media(max-width:620px){.foot .meta{margin-left:0;width:100%}}
-
-@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
 </style>
 </head>
 <body>

--- a/apps/api/public/terms.html
+++ b/apps/api/public/terms.html
@@ -86,7 +86,7 @@
 *{box-sizing:border-box;margin:0}
 /* scroll-padding-top clears the 60px sticky header, which would otherwise sit
    on top of whatever an in-page anchor just jumped to. */
-html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px;scroll-behavior:smooth}
+html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px}
 body{
   background:var(--bg);color:var(--fg);
   font-family:var(--sans);font-size:16px;line-height:1.6;
@@ -215,8 +215,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 .foot a:hover{color:var(--fg)}
 .foot .meta{margin-left:auto}
 @media(max-width:620px){.foot .meta{margin-left:0;width:100%}}
-
-@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}
 </style>
 </head>
 <body>

--- a/packages/site/src/tokens.css
+++ b/packages/site/src/tokens.css
@@ -45,7 +45,7 @@
 *{box-sizing:border-box;margin:0}
 /* scroll-padding-top clears the 60px sticky header, which would otherwise sit
    on top of whatever an in-page anchor just jumped to. */
-html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px;scroll-behavior:smooth}
+html{-webkit-text-size-adjust:100%;color-scheme:dark;scroll-padding-top:76px}
 body{
   background:var(--bg);color:var(--fg);
   font-family:var(--sans);font-size:16px;line-height:1.6;
@@ -174,5 +174,3 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 .foot a:hover{color:var(--fg)}
 .foot .meta{margin-left:auto}
 @media(max-width:620px){.foot .meta{margin-left:0;width:100%}}
-
-@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto}}


### PR DESCRIPTION
Anchor links like `#download` animated the whole page past everything in between. Dropping `scroll-behavior:smooth` makes the browser jump straight to the target.

- `packages/site/src/tokens.css`: removed `scroll-behavior:smooth` from `html`, and with it the `prefers-reduced-motion` override that only existed to undo it. `scroll-padding-top:76px` stays, so the sticky header still doesn't cover the target.
- `apps/api/public/index.html`: same two edits in the landing page's own copy of the CSS.
- Regenerated the site (`make gen-site`, `make gen-site-md`).

Verified: `make check-site-html`, `make check-site-md`, `make lint` all pass. Not exercised: no browser check of the rendered page — the change is purely the removal of a CSS property.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJkjz4mbQCHVwYdBqVDo2n)_