### PR TITLE
Rewrite the Mac shot's caption

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1360,7 +1360,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
           <img class="mac-shot" src="/screens/mac-cut.webp" width="840" height="1296" loading="lazy"
                alt="The inbox hanging from the Mac menu bar: the bell sits in the bar and the popover beneath it lists the day's notifications, the urgent one in red.">
         </div>
-        <figcaption>The inbox, from the Mac menu bar. Notifications are stored here, on the device (deleted from our servers as soon as it collects them).</figcaption>
+        <figcaption>The inbox, from the Mac menu bar. Notifications are stored here, on the device (deleted from our servers immediately after receiving).</figcaption>
       </figure>
     </div>
 

--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1360,7 +1360,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
           <img class="mac-shot" src="/screens/mac-cut.webp" width="840" height="1296" loading="lazy"
                alt="The inbox hanging from the Mac menu bar: the bell sits in the bar and the popover beneath it lists the day's notifications, the urgent one in red.">
         </div>
-        <figcaption>The inbox, from the Mac menu bar. The banner goes; the notification stays.</figcaption>
+        <figcaption>The inbox, from the Mac menu bar. Notifications are stored here, on the device.</figcaption>
       </figure>
     </div>
 

--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1360,7 +1360,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
           <img class="mac-shot" src="/screens/mac-cut.webp" width="840" height="1296" loading="lazy"
                alt="The inbox hanging from the Mac menu bar: the bell sits in the bar and the popover beneath it lists the day's notifications, the urgent one in red.">
         </div>
-        <figcaption>The inbox, from the Mac menu bar. The only place a notification permanently rests.</figcaption>
+        <figcaption>The inbox, from the Mac menu bar. The banner goes; the notification stays.</figcaption>
       </figure>
     </div>
 

--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1360,7 +1360,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
           <img class="mac-shot" src="/screens/mac-cut.webp" width="840" height="1296" loading="lazy"
                alt="The inbox hanging from the Mac menu bar: the bell sits in the bar and the popover beneath it lists the day's notifications, the urgent one in red.">
         </div>
-        <figcaption>The inbox, from the Mac menu bar. Notifications are stored here, on the device.</figcaption>
+        <figcaption>The inbox, from the Mac menu bar. Notifications are stored here, on the device (deleted from our servers as soon as it collects them).</figcaption>
       </figure>
     </div>
 


### PR DESCRIPTION
"The only place a notification permanently rests" overclaimed and read like filler. The caption now says plainly where notifications live, and notes that the server drops them once delivered:

> The inbox, from the Mac menu bar. Notifications are stored here, on the device (deleted from our servers immediately after receiving).

One line in the hand-kept body of `apps/api/public/index.html`; nothing generated changes and `make check-site-html` passes. No UI change, so no screenshots.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTdEdcWU47wjdgNUd25bXF)_