### PR TITLE
Mac: drop the share item from the row menu, and pad the offline banner

### DIFF
--- a/apps/app/Shared/Views/Components/MessageFeed.swift
+++ b/apps/app/Shared/Views/Components/MessageFeed.swift
@@ -143,7 +143,9 @@ struct MessageFeed<Empty: View>: View {
             Button(Copy.Inbox.copyLink) { Clipboard.copy(link.absoluteString) }
             if LinkPolicy.allows(link, anyScheme: model.allowsAnyLink(keyID: message.keyID)) {
                 Button(Copy.Common.openLink) { open(link, keyID: message.keyID) }
-                ShareLink(item: link) { Label(Copy.Message.shareLink, systemImage: "square.and.arrow.up") }
+                #if os(iOS)
+                ShareLink(item: link) { Text(Copy.Message.shareLink) }
+                #endif
             }
         }
         Divider()

--- a/apps/app/Shared/Views/InboxView.swift
+++ b/apps/app/Shared/Views/InboxView.swift
@@ -78,6 +78,9 @@ struct InboxView: View {
 
             if isOffline {
                 InlineError(message: Copy.Inbox.offline, followsAction: false)
+                    #if os(macOS)
+                    .padding(.top, 14)
+                    #endif
                     .padding(.bottom, 14)
                     .geistGutter()
             }


### PR DESCRIPTION
ShareLink draws its own glyph on macOS whatever label it is given, and the icon column it forces truncated "Copy notification" mid-word in the row context menu — the Mac already has Copy link and Open link, so the share item is now iOS-only. The offline banner also gains 14pt above it on macOS, matching the 14 below.