### PR TITLE
Make the image viewer's gestures physical

### DIFF
--- a/apps/app/Shared/NotifiApp.swift
+++ b/apps/app/Shared/NotifiApp.swift
@@ -129,6 +129,7 @@ struct RootContentView: View {
                     await model.refresh()
                 }
                 #if os(iOS)
+                Haptics.prepare()
                 model.startLiveUpdates()
                 #else
                 Updater.shared.checkInBackground()

--- a/apps/app/Shared/Support/Haptics.swift
+++ b/apps/app/Shared/Support/Haptics.swift
@@ -4,27 +4,45 @@ import UIKit
 
 @MainActor
 enum Haptics {
+    #if os(iOS)
+    private static let selectionGenerator = UISelectionFeedbackGenerator()
+    private static let impactGenerator = UIImpactFeedbackGenerator(style: .light)
+    private static let notificationGenerator = UINotificationFeedbackGenerator()
+    #endif
+
+    static func prepare() {
+        #if os(iOS)
+        selectionGenerator.prepare()
+        impactGenerator.prepare()
+        notificationGenerator.prepare()
+        #endif
+    }
+
     static func selection() {
         #if os(iOS)
-        UISelectionFeedbackGenerator().selectionChanged()
+        selectionGenerator.selectionChanged()
+        selectionGenerator.prepare()
         #endif
     }
 
     static func tap() {
         #if os(iOS)
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        impactGenerator.impactOccurred()
+        impactGenerator.prepare()
         #endif
     }
 
     static func success() {
         #if os(iOS)
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        notificationGenerator.notificationOccurred(.success)
+        notificationGenerator.prepare()
         #endif
     }
 
     static func error() {
         #if os(iOS)
-        UINotificationFeedbackGenerator().notificationOccurred(.error)
+        notificationGenerator.notificationOccurred(.error)
+        notificationGenerator.prepare()
         #endif
     }
 }

--- a/apps/app/Shared/Support/Markdown.swift
+++ b/apps/app/Shared/Support/Markdown.swift
@@ -147,7 +147,7 @@ private struct CodeCopyButton: View {
                 .overlay(RoundedRectangle(cornerRadius: Theme.innerRadius).stroke(Theme.chip, lineWidth: 1))
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.geist)
         .padding(6)
         .accessibilityLabel(copied ? Copy.Common.copied : Copy.Common.copy)
     }

--- a/apps/app/Shared/Support/Theme.swift
+++ b/apps/app/Shared/Support/Theme.swift
@@ -123,6 +123,8 @@ enum Theme {
 
     static let reveal = Animation.easeOut(duration: 0.25)
 
+    static let settle = Animation.spring(duration: 0.4, bounce: 0.2)
+
     static var reduceMotion: Bool {
         #if os(iOS)
         UIAccessibility.isReduceMotionEnabled

--- a/apps/app/Shared/Views/Components/FeedHeader.swift
+++ b/apps/app/Shared/Views/Components/FeedHeader.swift
@@ -94,7 +94,7 @@ struct FeedHeader<Trailing: View, Accessory: View>: View {
                 .geistHitArea(expandedBy: 5)
         }
         .menuStyle(.button)
-        .buttonStyle(.plain)
+        .buttonStyle(.geist)
         .menuIndicator(.hidden)
         .fixedSize()
         .accessibilityLabel(Copy.Inbox.more)

--- a/apps/app/Shared/Views/Components/GeistComponents.swift
+++ b/apps/app/Shared/Views/Components/GeistComponents.swift
@@ -364,10 +364,10 @@ struct SegmentedRow<Option: Hashable>: View {
                             .foregroundStyle(isSelected ? Theme.fg : Theme.dim)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 6)
+                            .background(isSelected ? Theme.surface : Color.clear)
                             .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
-                    .background(isSelected ? Theme.surface : Color.clear)
+                    .buttonStyle(.geistRow)
                     .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
 
                     if index < options.count - 1 {

--- a/apps/app/Shared/Views/Components/GeistTabBar.swift
+++ b/apps/app/Shared/Views/Components/GeistTabBar.swift
@@ -96,7 +96,7 @@ private struct TabButton: View {
             .frame(maxWidth: .infinity)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.geist)
         .overlay {
             HoverZone { hovering = $0 }
                 .frame(width: 28, height: 28)

--- a/apps/app/Shared/Views/Components/ImageViewer.swift
+++ b/apps/app/Shared/Views/Components/ImageViewer.swift
@@ -3,17 +3,31 @@ import SwiftUI
 struct ImageViewer: View {
     let url: URL
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var zoom: CGFloat = 1
     @State private var pinch: CGFloat = 1
     @State private var offset: CGSize = .zero
     @State private var dragged: CGSize = .zero
+    @State private var pinched: CGSize = .zero
+    @State private var fitted: CGSize = .zero
 
     private static let maxZoom: CGFloat = 8
 
     private static let tapZoom: CGFloat = 3
 
+    private static let decelerationRate: CGFloat = 0.998
+
+    private static let resistance: CGFloat = 0.55
+
     private var scale: CGFloat { min(max(zoom * pinch, 1), Self.maxZoom) }
+
+    private var settle: Animation { reduceMotion ? Theme.state : Theme.settle }
+
+    private var translation: CGSize {
+        CGSize(width: offset.width + dragged.width + pinched.width,
+               height: offset.height + dragged.height + pinched.height)
+    }
 
     var body: some View {
         GeometryReader { proxy in
@@ -26,12 +40,13 @@ struct ImageViewer: View {
                         image
                             .resizable()
                             .scaledToFit()
+                            .onGeometryChange(for: CGSize.self) { $0.size } action: { fitted = $0 }
                             .scaleEffect(scale)
-                            .offset(x: offset.width + dragged.width,
-                                    y: offset.height + dragged.height)
-                            .gesture(pan(in: proxy.size))
-                            .gesture(magnify(in: proxy.size))
-                            .onTapGesture(count: 2) { toggleZoom(in: proxy.size) }
+                            .offset(x: translation.width, y: translation.height)
+                            .gesture(SimultaneousGesture(pan(in: proxy.size), magnify(in: proxy.size)))
+                            .onTapGesture(count: 2) { location in
+                                toggleZoom(at: location, in: proxy.size)
+                            }
                     case .failure:
                         message(Copy.Message.imageFailedToLoad)
                     default:
@@ -75,45 +90,97 @@ struct ImageViewer: View {
         DragGesture()
             .onChanged { value in
                 guard scale > 1 else { return }
-                dragged = value.translation
+                dragged = resisted(value.translation, in: size)
             }
-            .onEnded { _ in
-                withAnimation(Theme.state) {
-                    offset = clamp(CGSize(width: offset.width + dragged.width,
-                                          height: offset.height + dragged.height),
-                                   in: size)
+            .onEnded { value in
+                guard scale > 1 else { return }
+                let released = CGSize(width: offset.width + dragged.width,
+                                      height: offset.height + dragged.height)
+                let projected = CGSize(
+                    width: released.width + Self.project(value.velocity.width),
+                    height: released.height + Self.project(value.velocity.height)
+                )
+                withAnimation(settle) {
                     dragged = .zero
+                    offset = clamp(projected, in: size)
                 }
             }
     }
 
     private func magnify(in size: CGSize) -> some Gesture {
         MagnifyGesture()
-            .onChanged { value in pinch = value.magnification }
+            .onChanged { value in
+                let previous = scale
+                pinch = value.magnification
+                let anchor = anchorPoint(value.startAnchor)
+                pinched = CGSize(width: pinched.width + anchor.x * (previous - scale),
+                                 height: pinched.height + anchor.y * (previous - scale))
+            }
             .onEnded { _ in
-                zoom = scale
+                let settled = scale
+                let combined = CGSize(width: offset.width + pinched.width,
+                                      height: offset.height + pinched.height)
+                zoom = settled
                 pinch = 1
-                withAnimation(Theme.state) {
-                    if zoom <= 1 { reset() } else { offset = clamp(offset, in: size) }
+                withAnimation(settle) {
+                    pinched = .zero
+                    if settled <= 1 { reset() } else { offset = clamp(combined, in: size) }
                 }
             }
     }
 
-    private func toggleZoom(in size: CGSize) {
-        withAnimation(Theme.state) {
+    private func toggleZoom(at location: CGPoint, in size: CGSize) {
+        withAnimation(settle) {
             if scale > 1 {
                 reset()
             } else {
+                let anchor = CGPoint(x: location.x - fitted.width / 2,
+                                     y: location.y - fitted.height / 2)
                 zoom = Self.tapZoom
+                offset = clamp(CGSize(width: anchor.x * (1 - Self.tapZoom),
+                                      height: anchor.y * (1 - Self.tapZoom)), in: size)
             }
         }
     }
 
+    private func anchorPoint(_ unit: UnitPoint) -> CGPoint {
+        CGPoint(x: (unit.x - 0.5) * fitted.width, y: (unit.y - 0.5) * fitted.height)
+    }
+
+    private func limits(in size: CGSize) -> CGSize {
+        CGSize(width: max(0, (fitted.width * scale - size.width) / 2),
+               height: max(0, (fitted.height * scale - size.height) / 2))
+    }
+
     private func clamp(_ proposed: CGSize, in size: CGSize) -> CGSize {
-        let limitX = max(0, (size.width * scale - size.width) / 2)
-        let limitY = max(0, (size.height * scale - size.height) / 2)
-        return CGSize(width: min(max(proposed.width, -limitX), limitX),
-                      height: min(max(proposed.height, -limitY), limitY))
+        let limit = limits(in: size)
+        return CGSize(width: min(max(proposed.width, -limit.width), limit.width),
+                      height: min(max(proposed.height, -limit.height), limit.height))
+    }
+
+    private func resisted(_ translation: CGSize, in size: CGSize) -> CGSize {
+        let limit = limits(in: size)
+        return CGSize(
+            width: Self.resist(translation.width, from: offset.width,
+                               limit: limit.width, dimension: size.width),
+            height: Self.resist(translation.height, from: offset.height,
+                                limit: limit.height, dimension: size.height)
+        )
+    }
+
+    private static func resist(_ translation: CGFloat, from origin: CGFloat,
+                               limit: CGFloat, dimension: CGFloat) -> CGFloat {
+        let proposed = origin + translation
+        let bounded = min(max(proposed, -limit), limit)
+        let overshoot = proposed - bounded
+        guard overshoot != 0 else { return translation }
+        let damped = (overshoot * dimension * resistance)
+            / (dimension + resistance * abs(overshoot))
+        return bounded + damped - origin
+    }
+
+    private static func project(_ velocity: CGFloat) -> CGFloat {
+        (velocity / 1000) * decelerationRate / (1 - decelerationRate)
     }
 
     private func reset() {
@@ -121,5 +188,6 @@ struct ImageViewer: View {
         pinch = 1
         offset = .zero
         dragged = .zero
+        pinched = .zero
     }
 }


### PR DESCRIPTION
The pan discarded release velocity and tracked unbounded past its own limits, the pinch and double-tap both scaled from the image's centre rather than from the fingers, and pan and pinch could not run at once; pan now projects momentum on release, resists progressively past the bound and settles on a spring, and both zooms hold the content under the gesture. Its clamp also used the container width on both sides of the subtraction, so a letterboxed image took its pan limits from the wrong dimension. Presses now register on the four controls that were still `.plain` — the Mac tab bar, the segmented row, the header menu and the code-block copy button — and the haptic generators are retained and prepared rather than built at the moment they fire.

Verified on the Simulator: a pinch anchored beside the chart's `loss` label kept that label on screen where centre-scaling would have thrown it to x = -192pt, and two drags of the same 100pt displacement ended 300pt apart once one of them was flicked. Rubber-banding is unverified — the resistance is only visible while the finger is down, and the release clamps either way.