### PR TITLE
Mark critical with a bolt, and make the feed's link glyph clickable

### DIFF
--- a/apps/app/Shared/Support/SampleData.swift
+++ b/apps/app/Shared/Support/SampleData.swift
@@ -314,12 +314,18 @@ enum SampleData {
                         ? ago(minutes).addingTimeInterval(-Double(index) * 0.437)
                         : nil,
                     isRead: !unread,
-                    isCritical: index == 0
+                    isCritical: Self.criticalTitles.contains(title)
                 )
             )
         }
         try? context.save()
     }
+
+    private static let criticalTitles: Set<String> = [
+        "Certificate for vault.internal.eu-west-2.compute.amazonaws.com expires in 7 days",
+        "Incident INC-2049 postmortem published for the multi-region outage that "
+            + "affected notification delivery for approximately six hours on 29 July",
+    ]
 
     @MainActor
     static func clear(from context: ModelContext) {

--- a/apps/app/Shared/Views/Components/MessageFeed.swift
+++ b/apps/app/Shared/Views/Components/MessageFeed.swift
@@ -92,7 +92,8 @@ struct MessageFeed<Empty: View>: View {
             model.path.append(message.serverID)
         } label: {
             MessageRow(message: message, now: now,
-                       showsRule: showsRule)
+                       showsRule: showsRule,
+                       openLink: openAction(for: message))
                 .contentShape(Rectangle())
         }
         .buttonStyle(.geistRow)
@@ -115,6 +116,13 @@ struct MessageFeed<Empty: View>: View {
         }
         #endif
         .contextMenu { menu(for: message) }
+    }
+
+    private func openAction(for message: Message) -> (() -> Void)? {
+        guard let link = message.link,
+              LinkPolicy.allows(link, anyScheme: model.allowsAnyLink(keyID: message.keyID))
+        else { return nil }
+        return { open(link, keyID: message.keyID) }
     }
 
     private var bands: [BandedMessages] {
@@ -320,10 +328,12 @@ private struct MessageRow: View {
     let message: Message
     let now: Date
     let showsRule: Bool
+    var openLink: (() -> Void)?
 
     @ScaledMetric(relativeTo: .caption2) private var slotIconSize: CGFloat = 11
 
     @State private var isHovered = false
+    @State private var isLinkHovered = false
     @State private var hoverTask: Task<Void, Never>?
 
     static let drawsRules = false
@@ -336,7 +346,17 @@ private struct MessageRow: View {
 
     private var basis: Date { message.occurredAt ?? message.createdAt }
 
-    private var isEscalated: Bool { !message.isRead || message.isCritical }
+    private var textWeight: Font.Weight { message.isRead ? .light : .regular }
+
+    private var textColor: Color {
+        message.isRead && !isHovered ? Theme.read : Theme.fg
+    }
+
+    private var previewColor: Color {
+        message.isRead && !isHovered ? Theme.muted : Theme.read
+    }
+
+    private var isEscalated: Bool { !message.isRead }
 
     private var preview: String? {
         guard let body = message.body else { return nil }
@@ -356,8 +376,9 @@ private struct MessageRow: View {
     private var content: some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
             Text(Self.clock.string(from: basis))
-                .font(.inco(size: 12, weight: isEscalated ? .semibold : .regular))
+                .font(.inco(size: 12, weight: textWeight))
                 .monospacedDigit()
+                .underline(message.isCritical, pattern: .solid)
                 .foregroundStyle(isEscalated ? Theme.brandText
                                  : isHovered ? Theme.muted : Theme.dim)
                 .lineLimit(1)
@@ -366,18 +387,22 @@ private struct MessageRow: View {
             VStack(alignment: .leading, spacing: 5) {
                 HStack(alignment: .firstTextBaseline, spacing: 12) {
                     MonoLine(text: message.title,
-                             font: .inco(size: 13.5, weight: isEscalated ? .bold : .regular,
+                             font: .inco(size: 13.5, weight: textWeight,
                                          relativeTo: .footnote))
-                        .foregroundStyle(message.isCritical ? Theme.brandText
-                                         : message.isRead && !isHovered ? Theme.read : Theme.fg)
+                        .foregroundStyle(textColor)
 
-                    slot(present: message.link != nil, systemName: "globe")
+                    slot(present: message.isCritical, systemName: "bolt")
+                    linkSlot
                     slot(present: message.imageURL != nil, systemName: "photo")
                 }
 
                 if let preview {
-                    MonoLine(text: preview, font: Theme.metaSmall)
-                        .foregroundStyle(isHovered ? Theme.dim : Theme.mark)
+                    Text(preview)
+                        .font(.karla(size: 12.5, weight: textWeight, relativeTo: .footnote))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .foregroundStyle(previewColor)
                 }
             }
         }
@@ -407,12 +432,38 @@ private struct MessageRow: View {
     }
 
     @ViewBuilder
+    private var linkSlot: some View {
+        #if os(macOS)
+        if message.link != nil, let openLink {
+            Button(action: openLink) {
+                glyph("globe")
+                    .foregroundStyle(isLinkHovered ? Theme.brandText : Theme.dim)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .animation(.easeOut(duration: 0.12), value: isLinkHovered)
+            .onHover { isLinkHovered = $0 }
+            .help(Copy.Common.openLink)
+            .accessibilityLabel(Copy.Common.openLink)
+        } else {
+            slot(present: message.link != nil, systemName: "globe")
+        }
+        #else
+        slot(present: message.link != nil, systemName: "globe")
+        #endif
+    }
+
+    private func glyph(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: slotIconSize, weight: .medium))
+            .frame(width: slotIconSize + 1)
+    }
+
+    @ViewBuilder
     private func slot(present: Bool, systemName: String) -> some View {
         if present {
-            Image(systemName: systemName)
-                .font(.system(size: slotIconSize, weight: .medium))
+            glyph(systemName)
                 .foregroundStyle(Theme.dim)
-                .frame(width: slotIconSize + 1)
                 .accessibilityHidden(true)
         }
     }

--- a/apps/app/Shared/Views/MessageDetailView.swift
+++ b/apps/app/Shared/Views/MessageDetailView.swift
@@ -183,7 +183,7 @@ struct MessageDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             Text(message.title)
                 .font(.inco(.title, weight: .bold))
-                .foregroundStyle(message.isCritical ? Theme.brandText : Theme.fg)
+                .foregroundStyle(Theme.fg)
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
                 .multilineTextAlignment(.center)
@@ -228,9 +228,17 @@ struct MessageDetailView: View {
             .accessibilityHidden(true)
     }
 
-    private func quietLine(_ name: String?, age: String, stamp: String) -> some View {
+    private func quietLine(_ name: String?, age: String, stamp: String,
+                           critical: Bool) -> some View {
         VStack(spacing: 5) {
             HStack(spacing: 6) {
+                if critical {
+                    Image(systemName: "bolt")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Theme.dim)
+                        .accessibilityLabel(Copy.Inbox.critical)
+                    Text("·").foregroundStyle(Theme.chip)
+                }
                 if let name {
                     keyGlyph(11, Theme.dim)
                     Text(name)
@@ -260,7 +268,8 @@ struct MessageDetailView: View {
         tappableKey(message) {
             quietLine(keyName(for: message),
                       age: Self.age(of: message),
-                      stamp: stamp)
+                      stamp: stamp,
+                      critical: message.isCritical)
         }
     }
 


### PR DESCRIPTION
The feed's globe now opens the link on macOS with a hover state, instead of only navigating into the message. Read state drives weight and colour across the whole row rather than the title alone, and the description moves to Karla one step up the grey ramp — it drops `MonoLine`, whose tracked ellipsis assumes a monospaced cell width. Critical stops being a colour and becomes a bolt glyph (a feed slot beside the globe, and the head of the detail page's meta line) plus an underlined timestamp, so colour is free to mean read/unread and a read critical message no longer looks identical to an unread one. Sample data marks two messages critical by title instead of pinning it to the newest row.