### PR TITLE
Mac: open the panel the first time a device identity is created

### DIFF
--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -209,6 +209,11 @@ final class AppModel {
         do {
             let identity = try DeviceIdentity.loadOrCreate()
             finishBoot(with: identity)
+            #if os(macOS)
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .notifiOpenPanel, object: nil)
+            }
+            #endif
         } catch NotifiError.unsupportedDevice {
             bootState = .unsupported
         } catch {


### PR DESCRIPTION
A menu bar app that has never been opened shows nothing after install: the bell appears and the user has to find it. `createIdentity()` is the one boot path a returning device never takes, and the Secure Enclave key survives a reinstall, so posting the open-panel notification there opens the popover exactly once per device rather than once per install or per launch. It also puts the restore-ack and unavailable screens in front of a fresh install, which were previously invisible until the bell was clicked. The post is deferred a run-loop turn because bootstrap runs inside `applicationDidFinishLaunching`, before the status item has a window to anchor to. Not exercised at runtime: that needs a Mac with no notifi keychain identity.