### PR TITLE
Mac: add a "Notifications stay visible" row to Settings

### DIFF
--- a/apps/app/Shared/AppDelegate.swift
+++ b/apps/app/Shared/AppDelegate.swift
@@ -61,6 +61,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         macAppModel.startLiveUpdates()
     }
 
+    func applicationDidBecomeActive(_ notification: Notification) {
+        Task {
+            await macAppModel.refreshPermission()
+        }
+    }
+
     func application(
         _ application: NSApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data

--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -444,7 +444,6 @@ final class AppModel {
         if SampleData.isEnabled {
             notificationStatus = .authorized
             criticalAlertStatus = .enabled
-            notificationsStayVisible = true
             return
         }
         #endif

--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -93,6 +93,7 @@ final class AppModel {
     var selectedTab: AppTab = AppTab.launchOverride ?? .inbox
     var notificationStatus: UNAuthorizationStatus = .notDetermined
     var criticalAlertStatus: UNNotificationSetting = .notSupported
+    var notificationsStayVisible = false
     var remoteImagesEnabled: Bool {
         didSet { RemoteImages.setEnabled(remoteImagesEnabled) }
     }
@@ -443,19 +444,26 @@ final class AppModel {
         if SampleData.isEnabled {
             notificationStatus = .authorized
             criticalAlertStatus = .enabled
+            notificationsStayVisible = true
             return
         }
         #endif
-        let settings: (UNAuthorizationStatus, UNNotificationSetting) =
+        let settings: (UNAuthorizationStatus, UNNotificationSetting, Bool) =
             await withCheckedContinuation { continuation in
                 UNUserNotificationCenter.current().getNotificationSettings { settings in
+                    #if os(macOS)
+                    let staysVisible = settings.alertStyle == .alert
+                    #else
+                    let staysVisible = false
+                    #endif
                     continuation.resume(
-                        returning: (settings.authorizationStatus, settings.criticalAlertSetting)
+                        returning: (settings.authorizationStatus, settings.criticalAlertSetting, staysVisible)
                     )
                 }
             }
         notificationStatus = settings.0
         criticalAlertStatus = settings.1
+        notificationsStayVisible = settings.2
     }
 
     func requestNotificationPermission() async {

--- a/apps/app/Shared/Resources/Localizable.xcstrings
+++ b/apps/app/Shared/Resources/Localizable.xcstrings
@@ -7636,6 +7636,111 @@
         }
       }
     },
+    "settings.stayVisible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications stay visible"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las notificaciones permanecen visibles"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen bleiben sichtbar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les notifications restent visibles"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le notifiche restano visibili"
+          }
+        }
+      }
+    },
+    "settings.stayVisibleDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A notification stays on screen until you click or dismiss it, instead of leaving after a few seconds. Enable opens System Settings, where you choose notifi’s alert style."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una notificación permanece en pantalla hasta que se pulse o se descarte, en lugar de desaparecer a los pocos segundos. Activar abre Ajustes del Sistema, donde se elige el estilo de alerta de notifi."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Benachrichtigung bleibt auf dem Bildschirm, bis du sie anklickst oder schließt, statt nach ein paar Sekunden zu verschwinden. „Aktivieren“ öffnet die Systemeinstellungen, in denen du den Hinweisstil von notifi wählst."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une notification reste à l’écran jusqu’à ce que vous cliquiez dessus ou la fermiez, au lieu de disparaître après quelques secondes. Activer ouvre les Réglages Système, où vous choisissez le style d’alerte de notifi."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una notifica resta sullo schermo finché non la clicchi o la chiudi, invece di sparire dopo pochi secondi. Attiva apre Impostazioni di Sistema, dove scegli lo stile di avviso di notifi."
+          }
+        }
+      }
+    },
+    "settings.stayVisibleEnable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva"
+          }
+        }
+      }
+    },
     "settings.strictSend": {
       "extractionState": "manual",
       "localizations": {

--- a/apps/app/Shared/Support/Copy.swift
+++ b/apps/app/Shared/Support/Copy.swift
@@ -187,6 +187,9 @@ enum Copy {
         static var permissionEphemeral: String { NSLocalizedString("settings.permissionEphemeral", comment: "") }
         static var permissionNotSet: String { NSLocalizedString("settings.permissionNotSet", comment: "") }
         static var permissionUnknown: String { NSLocalizedString("settings.permissionUnknown", comment: "") }
+        static var stayVisible: String { NSLocalizedString("settings.stayVisible", comment: "") }
+        static var stayVisibleDetail: String { NSLocalizedString("settings.stayVisibleDetail", comment: "") }
+        static var stayVisibleEnable: String { NSLocalizedString("settings.stayVisibleEnable", comment: "") }
         static var theme: String { NSLocalizedString("settings.theme", comment: "") }
         static var themeDark: String { NSLocalizedString("settings.themeDark", comment: "") }
         static var themeLight: String { NSLocalizedString("settings.themeLight", comment: "") }

--- a/apps/app/Shared/Views/Components/GeistComponents.swift
+++ b/apps/app/Shared/Views/Components/GeistComponents.swift
@@ -207,6 +207,7 @@ struct OutlineButton: View {
     var color: Color = Theme.fg
     var role: ButtonRole?
     var fill: Bool = true
+    var compact: Bool = false
     var action: () -> Void
 
     private var tint: Color { role == .destructive ? Theme.danger : color }
@@ -215,17 +216,18 @@ struct OutlineButton: View {
     var body: some View {
         Button(role: role, action: action) {
             Text(title)
-                .font(.inco(.footnote, weight: .semibold))
+                .font(.inco(compact ? .caption : .footnote, weight: .semibold))
                 .foregroundStyle(tint)
                 .frame(maxWidth: fill ? .infinity : nil)
-                .padding(.horizontal, fill ? 0 : 14)
-                .padding(.vertical, 11)
-                .frame(minHeight: Theme.minTarget)
+                .padding(.horizontal, fill ? 0 : compact ? 12 : 14)
+                .padding(.vertical, compact ? 6 : 11)
+                .frame(minHeight: compact ? nil : Theme.minTarget)
                 .contentShape(Rectangle())
-                .overlay(RoundedRectangle(cornerRadius: 8)
+                .overlay(RoundedRectangle(cornerRadius: compact ? Theme.radius : 8)
                     .stroke(border, lineWidth: 1))
         }
         .buttonStyle(.geist)
+        .geistHitArea(expandedBy: compact ? 8 : 0)
     }
 }
 
@@ -283,44 +285,70 @@ extension FieldRow where Trailing == FieldValue {
     }
 }
 
-struct ToggleRow: View {
+struct RowTitle: View {
     let title: String
     var detail: String?
-    @Binding var isOn: Bool
 
     @ScaledMetric(relativeTo: .subheadline) private var infoIconSize: CGFloat = 14
 
     @State private var showingDetail = false
 
     var body: some View {
-        HStack(spacing: 10) {
-            HStack(spacing: 6) {
-                Text(title)
-                    .font(Theme.body)
-                    .foregroundStyle(Theme.fg)
-                    .fixedSize(horizontal: false, vertical: true)
-                if let detail {
-                    Button {
-                        showingDetail = true
-                    } label: {
-                        Image(systemName: "info.circle")
-                            .font(.system(size: infoIconSize, weight: .medium))
-                            .foregroundStyle(Theme.dim)
-                    }
-                    .buttonStyle(.geist)
-                    .geistHitArea(expandedBy: 12)
-                    .accessibilityHidden(true)
-                    .popover(isPresented: $showingDetail, arrowEdge: .bottom) {
-                        Text(detail)
-                            .font(Theme.body)
-                            .foregroundStyle(Theme.fg)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .padding(14)
-                            .frame(idealWidth: 280, maxWidth: 280)
-                            .presentationCompactAdaptation(.popover)
-                    }
+        HStack(spacing: 6) {
+            Text(title)
+                .font(Theme.body)
+                .foregroundStyle(Theme.fg)
+                .fixedSize(horizontal: false, vertical: true)
+            if let detail {
+                Button {
+                    showingDetail = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: infoIconSize, weight: .medium))
+                        .foregroundStyle(Theme.dim)
+                }
+                .buttonStyle(.geist)
+                .geistHitArea(expandedBy: 12)
+                .accessibilityHidden(true)
+                .popover(isPresented: $showingDetail, arrowEdge: .bottom) {
+                    Text(detail)
+                        .font(Theme.body)
+                        .foregroundStyle(Theme.fg)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(14)
+                        .frame(idealWidth: 280, maxWidth: 280)
+                        .presentationCompactAdaptation(.popover)
                 }
             }
+        }
+    }
+}
+
+struct LabeledRow<Trailing: View>: View {
+    let title: String
+    var detail: String?
+    @ViewBuilder var trailing: Trailing
+
+    var body: some View {
+        HStack(spacing: 10) {
+            RowTitle(title: title, detail: detail)
+            Spacer(minLength: 8)
+            trailing
+        }
+        .padding(.vertical, Theme.rowPadV)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(title)
+    }
+}
+
+struct ToggleRow: View {
+    let title: String
+    var detail: String?
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            RowTitle(title: title, detail: detail)
             Spacer(minLength: 8)
             Toggle(title, isOn: $isOn)
                 .labelsHidden()

--- a/apps/app/Shared/Views/SettingsView.swift
+++ b/apps/app/Shared/Views/SettingsView.swift
@@ -37,19 +37,15 @@ struct SettingsView: View {
                     }
 
                     #if os(macOS)
-                    LabeledRow(title: Copy.Settings.stayVisible, detail: Copy.Settings.stayVisibleDetail) {
-                        if model.notificationsStayVisible {
-                            Text(Copy.Settings.permissionEnabled)
-                                .font(.inco(.subheadline, weight: .medium))
-                                .foregroundStyle(Theme.muted)
-                        } else {
+                    if !model.notificationsStayVisible {
+                        LabeledRow(title: Copy.Settings.stayVisible, detail: Copy.Settings.stayVisibleDetail) {
                             OutlineButton(title: Copy.Settings.stayVisibleEnable, fill: false, compact: true) {
                                 model.openSystemNotificationSettings()
                             }
                         }
+                        .geistGutter()
+                        RowRule()
                     }
-                    .geistGutter()
-                    RowRule()
                     #endif
 
                     ToggleRow(

--- a/apps/app/Shared/Views/SettingsView.swift
+++ b/apps/app/Shared/Views/SettingsView.swift
@@ -36,6 +36,22 @@ struct SettingsView: View {
                         RowRule()
                     }
 
+                    #if os(macOS)
+                    LabeledRow(title: Copy.Settings.stayVisible, detail: Copy.Settings.stayVisibleDetail) {
+                        if model.notificationsStayVisible {
+                            Text(Copy.Settings.permissionEnabled)
+                                .font(.inco(.subheadline, weight: .medium))
+                                .foregroundStyle(Theme.muted)
+                        } else {
+                            OutlineButton(title: Copy.Settings.stayVisibleEnable, fill: false, compact: true) {
+                                model.openSystemNotificationSettings()
+                            }
+                        }
+                    }
+                    .geistGutter()
+                    RowRule()
+                    #endif
+
                     ToggleRow(
                         title: Copy.Settings.loadImages,
                         detail: Copy.Settings.loadImagesDetail,

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -319,6 +319,12 @@ export const copy = {
     permissionNotSet: 'Not set',
     permissionUnknown: 'Unknown',
 
+    stayVisible: 'Notifications stay visible',
+    stayVisibleDetail:
+      'A notification stays on screen until you click or dismiss it, instead of leaving after ' +
+      'a few seconds. Enable opens System Settings, where you choose notifi’s alert style.',
+    stayVisibleEnable: 'Enable',
+
     theme: 'Theme',
     themeDark: 'Dark',
     themeLight: 'Light',

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -293,6 +293,13 @@ export const de: Translation = {
   'settings.permissionNotSet': 'Nicht festgelegt',
   'settings.permissionUnknown': 'Unbekannt',
 
+  'settings.stayVisible': 'Benachrichtigungen bleiben sichtbar',
+  'settings.stayVisibleDetail':
+    'Eine Benachrichtigung bleibt auf dem Bildschirm, bis du sie anklickst oder schließt, statt nach ' +
+    'ein paar Sekunden zu verschwinden. „Aktivieren“ öffnet die Systemeinstellungen, in denen du den ' +
+    'Hinweisstil von notifi wählst.',
+  'settings.stayVisibleEnable': 'Aktivieren',
+
   'settings.theme': 'Design',
   'settings.themeDark': 'Dunkel',
   'settings.themeLight': 'Hell',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -245,6 +245,12 @@ export const es: Translation = {
   'settings.permissionNotSet': 'Sin definir',
   'settings.permissionUnknown': 'Desconocido',
 
+  'settings.stayVisible': 'Las notificaciones permanecen visibles',
+  'settings.stayVisibleDetail':
+    'Una notificación permanece en pantalla hasta que se pulse o se descarte, en lugar de desaparecer ' +
+    'a los pocos segundos. Activar abre Ajustes del Sistema, donde se elige el estilo de alerta de notifi.',
+  'settings.stayVisibleEnable': 'Activar',
+
   'settings.theme': 'Tema',
   'settings.themeDark': 'Oscuro',
   'settings.themeLight': 'Claro',

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -248,6 +248,13 @@ export const fr: Translation = {
   'settings.permissionNotSet': 'Non défini',
   'settings.permissionUnknown': 'Inconnue',
 
+  'settings.stayVisible': 'Les notifications restent visibles',
+  'settings.stayVisibleDetail':
+    "Une notification reste à l’écran jusqu’à ce que vous cliquiez dessus ou la fermiez, au lieu de " +
+    "disparaître après quelques secondes. Activer ouvre les Réglages Système, où vous choisissez le style " +
+    "d’alerte de notifi.",
+  'settings.stayVisibleEnable': 'Activer',
+
   'settings.theme': 'Thème',
   'settings.themeDark': 'Sombre',
   'settings.themeLight': 'Clair',

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -245,6 +245,12 @@ export const it: Translation = {
   'settings.permissionNotSet': 'Non impostata',
   'settings.permissionUnknown': 'Sconosciuta',
 
+  'settings.stayVisible': 'Le notifiche restano visibili',
+  'settings.stayVisibleDetail':
+    'Una notifica resta sullo schermo finché non la clicchi o la chiudi, invece di sparire dopo pochi ' +
+    'secondi. Attiva apre Impostazioni di Sistema, dove scegli lo stile di avviso di notifi.',
+  'settings.stayVisibleEnable': 'Attiva',
+
   'settings.theme': 'Tema',
   'settings.themeDark': 'Scuro',
   'settings.themeLight': 'Chiaro',


### PR DESCRIPTION
Only System Settings can decide whether a notification leaves on its own or stays until it is clicked or dismissed, so the new row under Permissions reads the alert style from `UNNotificationSettings` and offers an Enable button that opens notifi's pane there, and hides itself once the style is already persistent. Permissions are refreshed whenever the app becomes active again, which removes the row after coming back from System Settings. The detail copy avoids naming the option because macOS 26 labels it Persistent where older versions said Alerts. Screenshots were captured from a CLI that cannot upload images and are attached via the web UI.