### PR TITLE
Keys hover, tighter ages, clearer settings help

### DIFF
--- a/apps/app/Shared/Resources/Localizable.xcstrings
+++ b/apps/app/Shared/Resources/Localizable.xcstrings
@@ -42,31 +42,31 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ d"
+            "value": "%1$@d"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ d"
+            "value": "%1$@d"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ T"
+            "value": "%1$@T"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ j"
+            "value": "%1$@j"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ g"
+            "value": "%1$@g"
           }
         }
       }
@@ -77,31 +77,31 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ hr"
+            "value": "%1$@h"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ h"
+            "value": "%1$@h"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ Std."
+            "value": "%1$@h"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ h"
+            "value": "%1$@h"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ h"
+            "value": "%1$@h"
           }
         }
       }
@@ -147,31 +147,31 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ min"
+            "value": "%1$@m"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ min"
+            "value": "%1$@min"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ Min."
+            "value": "%1$@min"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ min"
+            "value": "%1$@min"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ min"
+            "value": "%1$@min"
           }
         }
       }
@@ -217,31 +217,31 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ w"
+            "value": "%1$@w"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ sem"
+            "value": "%1$@sem"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ W"
+            "value": "%1$@W"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ sem."
+            "value": "%1$@sem."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@ sett"
+            "value": "%1$@sett"
           }
         }
       }
@@ -7041,6 +7041,41 @@
         }
       }
     },
+    "settings.docs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Docs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documentación"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dokumentation"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documentation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documentazione"
+          }
+        }
+      }
+    },
     "settings.feedback": {
       "extractionState": "manual",
       "localizations": {
@@ -7257,31 +7292,31 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fetches each image as the notification arrives, which tells its host your IP address. Off, images load only when tapped."
+            "value": "Fetches each image the moment its notification arrives.\n\nThe image’s host sees your IP address when that happens.\n\nOff, an image loads only when you tap it."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Obtiene cada imagen al llegar la notificación, lo que informa tu dirección IP a su host. Desactivado, las imágenes solo se cargan al pulsarlas."
+            "value": "Obtiene cada imagen en cuanto llega su notificación.\n\nEl host de la imagen ve tu dirección IP cuando eso ocurre.\n\nDesactivado, una imagen solo se carga al pulsarla."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ruft jedes Bild ab, sobald die Benachrichtigung ankommt, was dem Host deine IP-Adresse verrät. Aus, Bilder laden erst bei Antippen."
+            "value": "Ruft jedes Bild ab, sobald seine Benachrichtigung ankommt.\n\nDer Host des Bildes sieht dabei deine IP-Adresse.\n\nAus, lädt ein Bild erst, wenn du es antippst."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Récupère chaque image dès l’arrivée de la notification, ce qui révèle votre adresse IP à son hôte. Désactivé, les images ne se chargent qu’au toucher."
+            "value": "Récupère chaque image dès l’arrivée de sa notification.\n\nL’hôte de l’image voit alors votre adresse IP.\n\nDésactivé, une image ne se charge que lorsque vous la touchez."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recupera ogni immagine all'arrivo della notifica, il che comunica al suo host il tuo indirizzo IP. Disattivato, le immagini si caricano solo quando vengono toccate."
+            "value": "Recupera ogni immagine non appena arriva la sua notifica.\n\nL'host dell'immagine vede il tuo indirizzo IP quando succede.\n\nDisattivato, un'immagine si carica solo quando la tocchi."
           }
         }
       }
@@ -7887,31 +7922,31 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "A notification stays on screen until you click or dismiss it, instead of leaving after a few seconds. Enable opens System Settings, where you choose notifi’s alert style."
+            "value": "Keeps a notification on screen until you click or dismiss it.\n\nOff, it slides away after a few seconds.\n\nEnable opens System Settings, where you pick notifi’s alert style."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Una notificación permanece en pantalla hasta que se pulse o se descarte, en lugar de desaparecer a los pocos segundos. Activar abre Ajustes del Sistema, donde se elige el estilo de alerta de notifi."
+            "value": "Mantiene una notificación en pantalla hasta que la pulses o la descartes.\n\nDesactivado, desaparece a los pocos segundos.\n\nActivar abre Ajustes del Sistema, donde se elige el estilo de alerta de notifi."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eine Benachrichtigung bleibt auf dem Bildschirm, bis du sie anklickst oder schließt, statt nach ein paar Sekunden zu verschwinden. „Aktivieren“ öffnet die Systemeinstellungen, in denen du den Hinweisstil von notifi wählst."
+            "value": "Hält eine Benachrichtigung auf dem Bildschirm, bis du sie anklickst oder schließt.\n\nAus, verschwindet sie nach ein paar Sekunden.\n\n„Aktivieren“ öffnet die Systemeinstellungen, in denen du den Hinweisstil von notifi wählst."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Une notification reste à l’écran jusqu’à ce que vous cliquiez dessus ou la fermiez, au lieu de disparaître après quelques secondes. Activer ouvre les Réglages Système, où vous choisissez le style d’alerte de notifi."
+            "value": "Garde une notification à l’écran jusqu’à ce que vous cliquiez dessus ou la fermiez.\n\nDésactivé, elle disparaît après quelques secondes.\n\nActiver ouvre les Réglages Système, où vous choisissez le style d’alerte de notifi."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Una notifica resta sullo schermo finché non la clicchi o la chiudi, invece di sparire dopo pochi secondi. Attiva apre Impostazioni di Sistema, dove scegli lo stile di avviso di notifi."
+            "value": "Tiene una notifica sullo schermo finché non la clicchi o la chiudi.\n\nDisattivato, sparisce dopo pochi secondi.\n\nAttiva apre Impostazioni di Sistema, dove scegli lo stile di avviso di notifi."
           }
         }
       }
@@ -7992,31 +8027,31 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Returns 422 invalid_content and stores nothing when a title or body is over length. Off, /send crops the field and returns 202 with a warnings array."
+            "value": "Refuses a send whose title or body is over length: /send answers 422 invalid_content and stores nothing.\n\nOff, the field is cropped and the send is accepted with a warnings array.\n\n[Read the docs](https://notifi.it/docs#response)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Devuelve 422 invalid_content y no guarda nada cuando un título o cuerpo supera la longitud. Desactivado, /send recorta el campo y devuelve 202 con un array de avisos."
+            "value": "Rechaza un envío cuyo título o cuerpo supera la longitud: /send responde 422 invalid_content y no guarda nada.\n\nDesactivado, el campo se recorta y el envío se acepta con un array warnings.\n\n[Leer la documentación](https://notifi.it/docs#response)"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gibt 422 invalid_content zurück und speichert nichts, wenn ein Titel oder ein Text zu lang ist. Aus, /send kürzt das Feld und gibt 202 mit einem warnings-Array zurück."
+            "value": "Lehnt einen Send ab, dessen Titel oder Text zu lang ist: /send antwortet mit 422 invalid_content und speichert nichts.\n\nAus, wird das Feld gekürzt und der Send mit einem warnings-Array angenommen.\n\n[Zur Dokumentation](https://notifi.it/docs#response)"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Renvoie 422 invalid_content et ne stocke rien lorsqu’un titre ou un corps dépasse la longueur autorisée. Désactivé, /send raccourcit le champ et renvoie 202 avec un tableau warnings."
+            "value": "Refuse un envoi dont le titre ou le corps dépasse la longueur autorisée : /send répond 422 invalid_content et ne stocke rien.\n\nDésactivé, le champ est raccourci et l’envoi est accepté avec un tableau warnings.\n\n[Lire la documentation](https://notifi.it/docs#response)"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Restituisce 422 invalid_content e non memorizza nulla quando un titolo o un corpo supera la lunghezza consentita. Disattivato, /send abbrevia il campo e restituisce 202 con un array di warnings."
+            "value": "Rifiuta un invio il cui titolo o corpo supera la lunghezza consentita: /send risponde 422 invalid_content e non memorizza nulla.\n\nDisattivato, il campo viene abbreviato e l'invio è accettato con un array warnings.\n\n[Leggi la documentazione](https://notifi.it/docs#response)"
           }
         }
       }

--- a/apps/app/Shared/Support/Copy.swift
+++ b/apps/app/Shared/Support/Copy.swift
@@ -226,6 +226,7 @@ enum Copy {
         static var feedback: String { NSLocalizedString("settings.feedback", comment: "") }
         static var privacyPolicy: String { NSLocalizedString("settings.privacyPolicy", comment: "") }
         static var website: String { NSLocalizedString("settings.website", comment: "") }
+        static var docs: String { NSLocalizedString("settings.docs", comment: "") }
     }
     enum Empty {
         static var sampleTitle: String { NSLocalizedString("empty.sampleTitle", comment: "") }

--- a/apps/app/Shared/Views/Components/GeistComponents.swift
+++ b/apps/app/Shared/Views/Components/GeistComponents.swift
@@ -296,6 +296,14 @@ struct RowTitle: View {
 
     @State private var showingDetail = false
 
+    private var detailText: AttributedString {
+        guard let detail else { return AttributedString() }
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: detail, options: options)) ?? AttributedString(detail)
+    }
+
     var body: some View {
         HStack(spacing: 6) {
             Text(title)
@@ -315,8 +323,9 @@ struct RowTitle: View {
                 .accessibilityLabel(title)
                 .accessibilityHint(detail)
                 .popover(isPresented: $showingDetail, arrowEdge: .bottom) {
-                    Text(detail)
+                    Text(detailText)
                         .font(Theme.body)
+                        .tint(Theme.brand)
                         .foregroundStyle(Theme.fg)
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(14)

--- a/apps/app/Shared/Views/Components/HoverHighlight.swift
+++ b/apps/app/Shared/Views/Components/HoverHighlight.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct HoverHighlight: ViewModifier {
+    var onChange: ((Bool) -> Void)? = nil
+
+    @State private var isHovered = false
+    @State private var hoverTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        #if os(macOS)
+        content
+            .background {
+                if isHovered {
+                    StaticField(level: .hover, fillsScreen: false)
+                }
+            }
+            .animation(.easeOut(duration: 0.12), value: isHovered)
+            .onHover { hovering in
+                hoverTask?.cancel()
+                guard hovering else {
+                    set(false)
+                    return
+                }
+                hoverTask = Task {
+                    try? await Task.sleep(for: .milliseconds(100))
+                    guard !Task.isCancelled else { return }
+                    set(true)
+                }
+            }
+        #else
+        content
+        #endif
+    }
+
+    private func set(_ hovering: Bool) {
+        isHovered = hovering
+        onChange?(hovering)
+    }
+}
+
+extension View {
+    func hoverHighlight(onChange: ((Bool) -> Void)? = nil) -> some View {
+        modifier(HoverHighlight(onChange: onChange))
+    }
+}

--- a/apps/app/Shared/Views/Components/MessageFeed.swift
+++ b/apps/app/Shared/Views/Components/MessageFeed.swift
@@ -340,7 +340,6 @@ private struct MessageRow: View {
 
     @State private var isHovered = false
     @State private var isLinkHovered = false
-    @State private var hoverTask: Task<Void, Never>?
 
     static let drawsRules = false
 
@@ -415,26 +414,7 @@ private struct MessageRow: View {
         .padding(.horizontal, 18)
         .padding(.vertical, 13)
         .frame(minHeight: 44)
-        #if os(macOS)
-        .background {
-            if isHovered {
-                StaticField(level: .hover, fillsScreen: false)
-            }
-        }
-        .animation(.easeOut(duration: 0.12), value: isHovered)
-        .onHover { hovering in
-            hoverTask?.cancel()
-            guard hovering else {
-                isHovered = false
-                return
-            }
-            hoverTask = Task {
-                try? await Task.sleep(for: .milliseconds(100))
-                guard !Task.isCancelled else { return }
-                isHovered = true
-            }
-        }
-        #endif
+        .hoverHighlight { isHovered = $0 }
     }
 
     @ViewBuilder

--- a/apps/app/Shared/Views/KeysView.swift
+++ b/apps/app/Shared/Views/KeysView.swift
@@ -60,6 +60,7 @@ struct KeysView: View {
                                 StaticField(level: .raised, fillsScreen: false)
                             }
                         }
+                        .hoverHighlight()
                         Hairline()
                     }
                 }
@@ -73,6 +74,7 @@ struct KeysView: View {
                         }
                         .buttonStyle(.geistRow)
                         .geistGutter()
+                        .hoverHighlight()
                         Hairline()
                     }
                 }

--- a/apps/app/Shared/Views/SettingsView.swift
+++ b/apps/app/Shared/Views/SettingsView.swift
@@ -253,6 +253,18 @@ struct SettingsView: View {
                     .geistGutter()
                     RowRule()
 
+                    Link(destination: URL(string: "https://notifi.it/docs")!) {
+                        DisclosureRow {
+                            Text(Copy.Settings.docs)
+                                .font(Theme.body)
+                                .foregroundStyle(Theme.fg)
+                        }
+                        .padding(.vertical, Theme.rowPadV)
+                    }
+                    .buttonStyle(.geistRow)
+                    .geistGutter()
+                    RowRule()
+
                     FieldRow(Copy.Settings.version, AppModel.appVersion)
                         .geistGutter()
                 }

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -121,10 +121,10 @@ export const copy = {
   age: {
     now: 'now',
     justNow: 'just now',
-    minutes: '{n} min',
-    hours: '{n} hr',
-    days: '{n} d',
-    weeks: '{n} w',
+    minutes: '{n}m',
+    hours: '{n}h',
+    days: '{n}d',
+    weeks: '{n}w',
     ago: '{relative} ago',
   },
 
@@ -326,8 +326,9 @@ export const copy = {
 
     stayVisible: 'Notifications stay visible',
     stayVisibleDetail:
-      'A notification stays on screen until you click or dismiss it, instead of leaving after ' +
-      'a few seconds. Enable opens System Settings, where you choose notifi’s alert style.',
+      'Keeps a notification on screen until you click or dismiss it.\n\n' +
+      'Off, it slides away after a few seconds.\n\n' +
+      'Enable opens System Settings, where you pick notifi’s alert style.',
     stayVisibleEnable: 'Enable',
 
     theme: 'Theme',
@@ -338,13 +339,16 @@ export const copy = {
 
     loadImages: 'Load images automatically',
     loadImagesDetail:
-      'Fetches each image as the notification arrives, which tells its host your IP address. ' +
-      'Off, images load only when tapped.',
+      'Fetches each image the moment its notification arrives.\n\n' +
+      'The image’s host sees your IP address when that happens.\n\n' +
+      'Off, an image loads only when you tap it.',
 
     strictSend: 'Reject invalid sends',
     strictSendDetail:
-      'Returns 422 invalid_content and stores nothing when a title or body is over ' +
-      'length. Off, /send crops the field and returns 202 with a warnings array.',
+      'Refuses a send whose title or body is over length: /send answers 422 invalid_content ' +
+      'and stores nothing.\n\n' +
+      'Off, the field is cropped and the send is accepted with a warnings array.\n\n' +
+      '[Read the docs](https://notifi.it/docs#response)',
     strictSendFailed: 'PATCH /devices/settings failed. Check your connection and try again.',
 
     testTitle: 'Hello from notifi',
@@ -370,6 +374,7 @@ export const copy = {
     feedback: 'Feedback',
     privacyPolicy: 'Privacy policy',
     website: 'notifi.it',
+    docs: 'Docs',
   },
 
   empty: {

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -111,10 +111,10 @@ export const de: Translation = {
 
   'age.now': 'jetzt',
   'age.justNow': 'gerade eben',
-  'age.minutes': '{n} Min.',
-  'age.hours': '{n} Std.',
-  'age.days': '{n} T',
-  'age.weeks': '{n} W',
+  'age.minutes': '{n}min',
+  'age.hours': '{n}h',
+  'age.days': '{n}T',
+  'age.weeks': '{n}W',
   'age.ago': 'vor {relative}',
   'inbox.title': 'Inbox',
   'inbox.offline': 'notifi-Server nicht erreichbar. Verbindung prüfen und erneut versuchen.',
@@ -300,9 +300,9 @@ export const de: Translation = {
 
   'settings.stayVisible': 'Benachrichtigungen bleiben sichtbar',
   'settings.stayVisibleDetail':
-    'Eine Benachrichtigung bleibt auf dem Bildschirm, bis du sie anklickst oder schließt, statt nach ' +
-    'ein paar Sekunden zu verschwinden. „Aktivieren“ öffnet die Systemeinstellungen, in denen du den ' +
-    'Hinweisstil von notifi wählst.',
+    'Hält eine Benachrichtigung auf dem Bildschirm, bis du sie anklickst oder schließt.\n\n' +
+    'Aus, verschwindet sie nach ein paar Sekunden.\n\n' +
+    '„Aktivieren“ öffnet die Systemeinstellungen, in denen du den Hinweisstil von notifi wählst.',
   'settings.stayVisibleEnable': 'Aktivieren',
 
   'settings.theme': 'Design',
@@ -313,13 +313,16 @@ export const de: Translation = {
 
   'settings.loadImages': 'Bilder automatisch laden',
   'settings.loadImagesDetail':
-    'Ruft jedes Bild ab, sobald die Benachrichtigung ankommt, was dem Host deine IP-Adresse verrät. ' +
-    'Aus, Bilder laden erst bei Antippen.',
+    'Ruft jedes Bild ab, sobald seine Benachrichtigung ankommt.\n\n' +
+    'Der Host des Bildes sieht dabei deine IP-Adresse.\n\n' +
+    'Aus, lädt ein Bild erst, wenn du es antippst.',
 
   'settings.strictSend': 'Ungültige Sendungen ablehnen',
   'settings.strictSendDetail':
-    'Gibt 422 invalid_content zurück und speichert nichts, wenn ein Titel oder ein Text zu lang ist. ' +
-    'Aus, /send kürzt das Feld und gibt 202 mit einem warnings-Array zurück.',
+    'Lehnt einen Send ab, dessen Titel oder Text zu lang ist: /send antwortet mit 422 invalid_content ' +
+    'und speichert nichts.\n\n' +
+    'Aus, wird das Feld gekürzt und der Send mit einem warnings-Array angenommen.\n\n' +
+    '[Zur Dokumentation](https://notifi.it/docs#response)',
   'settings.strictSendFailed': 'PATCH /devices/settings fehlgeschlagen. Verbindung prüfen und erneut versuchen.',
 
   'settings.testTitle': 'Hello from notifi',
@@ -347,6 +350,7 @@ export const de: Translation = {
   'settings.feedback': 'Feedback',
   'settings.privacyPolicy': 'Datenschutzerklärung',
   'settings.website': 'notifi.it',
+  'settings.docs': 'Dokumentation',
 
   'empty.sampleTitle': 'Hello from notifi',
   'empty.sampleMessage': 'Deine erste Benachrichtigung.',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -63,10 +63,10 @@ export const es: Translation = {
 
   'age.now': 'ahora',
   'age.justNow': 'ahora mismo',
-  'age.minutes': '{n} min',
-  'age.hours': '{n} h',
-  'age.days': '{n} d',
-  'age.weeks': '{n} sem',
+  'age.minutes': '{n}min',
+  'age.hours': '{n}h',
+  'age.days': '{n}d',
+  'age.weeks': '{n}sem',
   'age.ago': 'hace {relative}',
   'inbox.title': 'Inbox',
   'inbox.offline': 'No se puede conectar con los servidores de notifi. Comprueba tu conexión e inténtalo de nuevo.',
@@ -252,8 +252,9 @@ export const es: Translation = {
 
   'settings.stayVisible': 'Las notificaciones permanecen visibles',
   'settings.stayVisibleDetail':
-    'Una notificación permanece en pantalla hasta que se pulse o se descarte, en lugar de desaparecer ' +
-    'a los pocos segundos. Activar abre Ajustes del Sistema, donde se elige el estilo de alerta de notifi.',
+    'Mantiene una notificación en pantalla hasta que la pulses o la descartes.\n\n' +
+    'Desactivado, desaparece a los pocos segundos.\n\n' +
+    'Activar abre Ajustes del Sistema, donde se elige el estilo de alerta de notifi.',
   'settings.stayVisibleEnable': 'Activar',
 
   'settings.theme': 'Tema',
@@ -264,13 +265,16 @@ export const es: Translation = {
 
   'settings.loadImages': 'Cargar imágenes automáticamente',
   'settings.loadImagesDetail':
-    'Obtiene cada imagen al llegar la notificación, lo que informa tu dirección IP a su host. ' +
-    'Desactivado, las imágenes solo se cargan al pulsarlas.',
+    'Obtiene cada imagen en cuanto llega su notificación.\n\n' +
+    'El host de la imagen ve tu dirección IP cuando eso ocurre.\n\n' +
+    'Desactivado, una imagen solo se carga al pulsarla.',
 
   'settings.strictSend': 'Rechazar envíos no válidos',
   'settings.strictSendDetail':
-    'Devuelve 422 invalid_content y no guarda nada cuando un título o cuerpo supera la ' +
-    'longitud. Desactivado, /send recorta el campo y devuelve 202 con un array de avisos.',
+    'Rechaza un envío cuyo título o cuerpo supera la longitud: /send responde 422 invalid_content ' +
+    'y no guarda nada.\n\n' +
+    'Desactivado, el campo se recorta y el envío se acepta con un array warnings.\n\n' +
+    '[Leer la documentación](https://notifi.it/docs#response)',
   'settings.strictSendFailed': 'PATCH /devices/settings falló. Comprueba tu conexión e inténtalo de nuevo.',
 
   'settings.testTitle': 'Hello from notifi',
@@ -298,6 +302,7 @@ export const es: Translation = {
   'settings.feedback': 'Comentarios',
   'settings.privacyPolicy': 'Política de privacidad',
   'settings.website': 'notifi.it',
+  'settings.docs': 'Documentación',
 
   'empty.sampleTitle': 'Hello from notifi',
   'empty.sampleMessage': 'Tu primera notificación.',

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -63,10 +63,10 @@ export const fr: Translation = {
 
   'age.now': 'à l’instant',
   'age.justNow': 'à l’instant',
-  'age.minutes': '{n} min',
-  'age.hours': '{n} h',
-  'age.days': '{n} j',
-  'age.weeks': '{n} sem.',
+  'age.minutes': '{n}min',
+  'age.hours': '{n}h',
+  'age.days': '{n}j',
+  'age.weeks': '{n}sem.',
   'age.ago': 'il y a {relative}',
   'inbox.title': 'Inbox',
   'inbox.offline':
@@ -255,9 +255,9 @@ export const fr: Translation = {
 
   'settings.stayVisible': 'Les notifications restent visibles',
   'settings.stayVisibleDetail':
-    "Une notification reste à l’écran jusqu’à ce que vous cliquiez dessus ou la fermiez, au lieu de " +
-    "disparaître après quelques secondes. Activer ouvre les Réglages Système, où vous choisissez le style " +
-    "d’alerte de notifi.",
+    "Garde une notification à l’écran jusqu’à ce que vous cliquiez dessus ou la fermiez.\n\n" +
+    "Désactivé, elle disparaît après quelques secondes.\n\n" +
+    "Activer ouvre les Réglages Système, où vous choisissez le style d’alerte de notifi.",
   'settings.stayVisibleEnable': 'Activer',
 
   'settings.theme': 'Thème',
@@ -268,13 +268,16 @@ export const fr: Translation = {
 
   'settings.loadImages': 'Charger les images automatiquement',
   'settings.loadImagesDetail':
-    "Récupère chaque image dès l’arrivée de la notification, ce qui révèle votre adresse IP à son " +
-    "hôte. Désactivé, les images ne se chargent qu’au toucher.",
+    "Récupère chaque image dès l’arrivée de sa notification.\n\n" +
+    "L’hôte de l’image voit alors votre adresse IP.\n\n" +
+    "Désactivé, une image ne se charge que lorsque vous la touchez.",
 
   'settings.strictSend': 'Rejeter les envois invalides',
   'settings.strictSendDetail':
-    "Renvoie 422 invalid_content et ne stocke rien lorsqu’un titre ou un corps dépasse la " +
-    "longueur autorisée. Désactivé, /send raccourcit le champ et renvoie 202 avec un tableau warnings.",
+    "Refuse un envoi dont le titre ou le corps dépasse la longueur autorisée : /send répond " +
+    "422 invalid_content et ne stocke rien.\n\n" +
+    "Désactivé, le champ est raccourci et l’envoi est accepté avec un tableau warnings.\n\n" +
+    "[Lire la documentation](https://notifi.it/docs#response)",
   'settings.strictSendFailed': 'Échec de PATCH /devices/settings. Vérifiez votre connexion et réessayez.',
 
   'settings.testTitle': 'Hello from notifi',
@@ -303,6 +306,7 @@ export const fr: Translation = {
   'settings.feedback': 'Avis',
   'settings.privacyPolicy': 'Politique de confidentialité',
   'settings.website': 'notifi.it',
+  'settings.docs': 'Documentation',
 
   'empty.sampleTitle': 'Hello from notifi',
   'empty.sampleMessage': 'Votre première notification.',

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -63,10 +63,10 @@ export const it: Translation = {
 
   'age.now': 'ora',
   'age.justNow': 'proprio ora',
-  'age.minutes': '{n} min',
-  'age.hours': '{n} h',
-  'age.days': '{n} g',
-  'age.weeks': '{n} sett',
+  'age.minutes': '{n}min',
+  'age.hours': '{n}h',
+  'age.days': '{n}g',
+  'age.weeks': '{n}sett',
   'age.ago': '{relative} fa',
   'inbox.title': 'Inbox',
   'inbox.offline': 'Impossibile raggiungere i server notifi. Controlla la connessione e riprova.',
@@ -252,8 +252,9 @@ export const it: Translation = {
 
   'settings.stayVisible': 'Le notifiche restano visibili',
   'settings.stayVisibleDetail':
-    'Una notifica resta sullo schermo finché non la clicchi o la chiudi, invece di sparire dopo pochi ' +
-    'secondi. Attiva apre Impostazioni di Sistema, dove scegli lo stile di avviso di notifi.',
+    'Tiene una notifica sullo schermo finché non la clicchi o la chiudi.\n\n' +
+    'Disattivato, sparisce dopo pochi secondi.\n\n' +
+    'Attiva apre Impostazioni di Sistema, dove scegli lo stile di avviso di notifi.',
   'settings.stayVisibleEnable': 'Attiva',
 
   'settings.theme': 'Tema',
@@ -264,13 +265,16 @@ export const it: Translation = {
 
   'settings.loadImages': 'Carica le immagini automaticamente',
   'settings.loadImagesDetail':
-    'Recupera ogni immagine all\'arrivo della notifica, il che comunica al suo host il tuo indirizzo IP. ' +
-    'Disattivato, le immagini si caricano solo quando vengono toccate.',
+    'Recupera ogni immagine non appena arriva la sua notifica.\n\n' +
+    'L\'host dell\'immagine vede il tuo indirizzo IP quando succede.\n\n' +
+    'Disattivato, un\'immagine si carica solo quando la tocchi.',
 
   'settings.strictSend': 'Rifiuta invii non validi',
   'settings.strictSendDetail':
-    'Restituisce 422 invalid_content e non memorizza nulla quando un titolo o un corpo supera la ' +
-    'lunghezza consentita. Disattivato, /send abbrevia il campo e restituisce 202 con un array di warnings.',
+    'Rifiuta un invio il cui titolo o corpo supera la lunghezza consentita: /send risponde ' +
+    '422 invalid_content e non memorizza nulla.\n\n' +
+    'Disattivato, il campo viene abbreviato e l\'invio è accettato con un array warnings.\n\n' +
+    '[Leggi la documentazione](https://notifi.it/docs#response)',
   'settings.strictSendFailed': 'PATCH /devices/settings non riuscito. Controlla la connessione e riprova.',
 
   'settings.testTitle': 'Hello from notifi',
@@ -298,6 +302,7 @@ export const it: Translation = {
   'settings.feedback': 'Feedback',
   'settings.privacyPolicy': 'Informativa sulla privacy',
   'settings.website': 'notifi.it',
+  'settings.docs': 'Documentazione',
 
   'empty.sampleTitle': 'Hello from notifi',
   'empty.sampleMessage': 'La tua prima notifica.',


### PR DESCRIPTION
Key rows highlight on hover on the Mac, full width, sharing the inbox row's hover through a new `HoverHighlight` modifier. Relative ages lose their space (`2h`, `3d`, `30w`) in every language. The three Permissions help bubbles are rewritten as short paragraphs, parsed as inline Markdown, and Reject invalid sends ends with a link to `notifi.it/docs#response`. About gains a Docs row under notifi.it, and screenshots follow from the web UI since this CLI cannot upload images.