### PR TITLE
Keys: sent and last use on their own lines

### DIFF
--- a/apps/app/Shared/Views/KeysView.swift
+++ b/apps/app/Shared/Views/KeysView.swift
@@ -140,18 +140,16 @@ private struct KeyRow: View {
                             .foregroundStyle(key.isRevoked ? Theme.read : Theme.fg)
                             .lineLimit(1)
                     }
-                    HStack(spacing: 10) {
-                        Text(key.maskedValue)
-                            .font(Theme.meta)
-                            .foregroundStyle(Theme.muted)
-                        Text(sent)
+                    Text(key.maskedValue)
+                        .font(Theme.meta)
+                        .foregroundStyle(Theme.muted)
+                    Text(sent)
+                        .font(Theme.metaSmall)
+                        .foregroundStyle(Theme.dim)
+                    if let used = key.lastUsedDate {
+                        Text(Copy.Keys.rowLastUsed(RelativeAge.agoString(since: used)))
                             .font(Theme.metaSmall)
                             .foregroundStyle(Theme.dim)
-                        if let used = key.lastUsedDate {
-                            Text(Copy.Keys.rowLastUsed(RelativeAge.agoString(since: used)))
-                                .font(Theme.metaSmall)
-                                .foregroundStyle(Theme.dim)
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Each key row now stacks the masked key, the sent count and the last use on separate lines instead of running them along one.