### PR TITLE
Install Mac updates without waiting for a quit that never comes

### DIFF
--- a/apps/app/Shared/Support/Updater.swift
+++ b/apps/app/Shared/Support/Updater.swift
@@ -2,26 +2,39 @@
 import Sparkle
 import SwiftUI
 
+private final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    func updater(
+        _ updater: SPUUpdater,
+        willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock: @escaping () -> Void
+    ) -> Bool {
+        immediateInstallationBlock()
+        return true
+    }
+}
+
 @MainActor
 @Observable
 final class Updater {
     static let shared = Updater()
 
     private let controller: SPUStandardUpdaterController
+    private let delegate = UpdaterDelegate()
     private(set) var canCheck = false
 
     private(set) var automaticallyInstalls = false
 
     private init() {
         controller = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
+            startingUpdater: false,
+            updaterDelegate: delegate,
             userDriverDelegate: nil
         )
         controller.updater.automaticallyChecksForUpdates = true
         if UserDefaults.standard.object(forKey: "SUAutomaticallyUpdate") == nil {
             controller.updater.automaticallyDownloadsUpdates = true
         }
+        controller.startUpdater()
         automaticallyInstalls = controller.updater.automaticallyDownloadsUpdates
         observation = controller.updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
             Task { @MainActor in self?.canCheck = updater.canCheckForUpdates }


### PR DESCRIPTION
Sparkle's automatic driver installs immediately only when the app has already terminated; otherwise it stages the update and waits for a quit, unless the updater delegate implements `updater:willInstallUpdateOnQuit:immediateInstallationBlock:` and calls the block. That delegate was `nil` and notifi is an `LSUIElement` menu bar app nobody quits, so a downloaded update sat prepared forever and the settings copy promising a relaunch was never true. The updater also starts explicitly now, after `automaticallyDownloadsUpdates` is set rather than just after it began scheduling. `notifi-macOS` builds and `make lint` passes; a real end-to-end update is not exercised, since that needs a signed DMG newer than the installed 2.0.18.