### PR TITLE
Store the device platform and app version in plain text

### DIFF
--- a/apps/api/public/privacy.html
+++ b/apps/api/public/privacy.html
@@ -272,7 +272,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
     <ul>
       <li>Two public keys: one for verifying requests, one for encrypting notifications to you.</li>
       <li>Your Apple push token, encrypted with a key held by the server, so notifications can be delivered. Alongside it, a keyed one-way hash of the same token, stored unencrypted: it lets the server recognise that a new registration comes from a device it already knows, so the old row can be retired instead of receiving duplicates. It identifies the physical device across identity resets, and this is the only thing it is used for.</li>
-      <li>The platform (<code>ios</code> or <code>macos</code>) and app version, encrypted with the same key.</li>
+      <li>The platform (<code>ios</code> or <code>macos</code>) and the app version, stored in plain text.</li>
       <li>When the device first registered, when it was last seen, how far it has collected, and a lifetime count of notifications sent to it.</li>
       <li>A rolling one-hour send counter, used for rate limiting, and the strict-send setting if you have turned it on.</li>
     </ul>

--- a/apps/api/public/privacy.md
+++ b/apps/api/public/privacy.md
@@ -20,7 +20,7 @@ The server identifies a device only by its public key. Nothing in the system lin
 
 - Two public keys: one for verifying requests, one for encrypting notifications to you.
 - Your Apple push token, encrypted with a key held by the server, so notifications can be delivered. Alongside it, a keyed one-way hash of the same token, stored unencrypted: it lets the server recognise that a new registration comes from a device it already knows, so the old row can be retired instead of receiving duplicates. It identifies the physical device across identity resets, and this is the only thing it is used for.
-- The platform (`ios` or `macos`) and app version, encrypted with the same key.
+- The platform (`ios` or `macos`) and the app version, stored in plain text.
 - When the device first registered, when it was last seen, how far it has collected, and a lifetime count of notifications sent to it.
 - A rolling one-hour send counter, used for rate limiting, and the strict-send setting if you have turned it on.
 

--- a/apps/api/src/lib/fieldcrypto.ts
+++ b/apps/api/src/lib/fieldcrypto.ts
@@ -34,10 +34,6 @@ export async function decryptField(env: Env, stored: string): Promise<string> {
   return new TextDecoder().decode(pt);
 }
 
-export async function encryptPadded(env: Env, plaintext: string): Promise<string> {
-  return encryptField(env, plaintext.padEnd(16, ' ').slice(0, 16));
-}
-
 let cachedHmacKey: CryptoKey | null = null;
 
 async function hmacKey(env: Env): Promise<CryptoKey> {

--- a/apps/api/src/routes/devices.ts
+++ b/apps/api/src/routes/devices.ts
@@ -1,7 +1,7 @@
 import { registerDeviceBody, updateDeviceSettingsBody } from '@notifi/contract';
 import { Hono } from 'hono';
 import { fromB64 } from '../lib/bytes.js';
-import { encryptField, encryptPadded, tokenHmacHex } from '../lib/fieldcrypto.js';
+import { encryptField, tokenHmacHex } from '../lib/fieldcrypto.js';
 import { errBody, t } from '../lib/respond.js';
 import { now } from '../lib/time.js';
 import { signatureAuth } from '../middleware.js';
@@ -49,8 +49,6 @@ devices.post('/devices', async (c) => {
   const apnsEnc = parsed.apns_token
     ? await encryptField(c.env, parsed.apns_token)
     : '';
-  const platformEnc = await encryptPadded(c.env, parsed.platform);
-  const versionEnc = await encryptPadded(c.env, parsed.app_version);
 
   const retireOthers = c.env.DB.prepare(
     `UPDATE devices SET apns_token = '', apns_token_hmac = 'retired:' || id
@@ -74,8 +72,8 @@ devices.post('/devices', async (c) => {
     parsed.encryption_public_key,
     apnsEnc,
     tokenHmac,
-    platformEnc,
-    versionEnc,
+    parsed.platform,
+    parsed.app_version,
     nowS,
     nowS,
   );

--- a/packages/site/pages/privacy.md
+++ b/packages/site/pages/privacy.md
@@ -28,7 +28,7 @@ The server identifies a device only by its public key. Nothing in the system lin
 
 - Two public keys: one for verifying requests, one for encrypting notifications to you.
 - Your Apple push token, encrypted with a key held by the server, so notifications can be delivered. Alongside it, a keyed one-way hash of the same token, stored unencrypted: it lets the server recognise that a new registration comes from a device it already knows, so the old row can be retired instead of receiving duplicates. It identifies the physical device across identity resets, and this is the only thing it is used for.
-- The platform (`ios` or `macos`) and app version, encrypted with the same key.
+- The platform (`ios` or `macos`) and the app version, stored in plain text.
 - When the device first registered, when it was last seen, how far it has collected, and a lifetime count of notifications sent to it.
 - A rolling one-hour send counter, used for rate limiting, and the strict-send setting if you have turned it on.
 


### PR DESCRIPTION
Both columns were encrypted with the server's own key, which the server already holds and uses whenever it reads them, so the encryption protected nothing and made the values unqueryable. They now store the plain 'ios'/'macos' string and build number; existing rows keep their ciphertext until the device next registers. The privacy policy is updated to match, and encryptPadded is removed with its last caller.