### PR TITLE
Serve every uncollected notification; ack explicitly

### DIFF
--- a/apps/api/src/routes/history.ts
+++ b/apps/api/src/routes/history.ts
@@ -18,30 +18,30 @@ history.get('/history', async (c) => {
   if (!parsed.success) {
     return c.json(errBody('invalid_request', t(c).api.invalidHistoryQuery), 400);
   }
-  const since = parsed.data.since ?? 0;
+  const ack = parsed.data.ack ?? 0;
   const limit = parsed.data.limit ?? 50;
+
+  if (ack > 0 && ack <= device.seq_counter) {
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        'UPDATE devices SET acked_id = MAX(acked_id, ?), last_seen_at = ? WHERE id = ?',
+      ).bind(ack, nowS, device.id),
+      c.env.DB.prepare('DELETE FROM messages WHERE device_id = ? AND device_seq <= ?').bind(
+        device.id,
+        ack,
+      ),
+    ]);
+  }
 
   const rows = await c.env.DB.prepare(
     `SELECT device_seq AS id, content_sealed, key_id, created_at, occurred_at
-     FROM messages WHERE device_id = ? AND device_seq > ? ORDER BY device_seq ASC LIMIT ?`,
+     FROM messages WHERE device_id = ? ORDER BY device_seq ASC LIMIT ?`,
   )
-    .bind(device.id, since, limit)
+    .bind(device.id, limit)
     .all<HistoryMessage>();
 
   const results = rows.results;
   const latest = results.length > 0 ? results[results.length - 1]!.id : null;
-
-  if (since > device.acked_id) {
-    await c.env.DB.batch([
-      c.env.DB.prepare(
-        'UPDATE devices SET acked_id = MAX(acked_id, ?), last_seen_at = ? WHERE id = ?',
-      ).bind(since, nowS, device.id),
-      c.env.DB.prepare('DELETE FROM messages WHERE device_id = ? AND device_seq <= ?').bind(
-        device.id,
-        since,
-      ),
-    ]);
-  }
 
   return c.json({ messages: results, latest_id: latest });
 });

--- a/apps/app/Shared/API/APIClient.swift
+++ b/apps/app/Shared/API/APIClient.swift
@@ -63,9 +63,9 @@ final class APIClient {
         }
     }
 
-    func history(since: Int, limit: Int) async throws -> HistoryResponse {
+    func history(ack: Int, limit: Int) async throws -> HistoryResponse {
         let items = [
-            URLQueryItem(name: "since", value: String(since)),
+            URLQueryItem(name: "ack", value: String(ack)),
             URLQueryItem(name: "limit", value: String(limit)),
         ]
         return try await performSigned {

--- a/apps/app/Shared/Store/SyncEngine.swift
+++ b/apps/app/Shared/Store/SyncEngine.swift
@@ -48,28 +48,24 @@ final class SyncEngine {
         return fresh
     }
 
-    private var bookmark: Int {
-        get { state.bookmark }
-        set { state.bookmark = newValue }
-    }
-
     func sync() async {
         guard !isSyncing else { return }
         isSyncing = true
         defer { isSyncing = false }
 
         var newMessages = 0
-        let firstSync = bookmark == 0
+        let firstSync = !state.hasSynced
         var arrivals: [Arrival] = []
         do {
+            var ack = 0
             var pagesFetched = 0
             pages: while pagesFetched < Self.maxPagesPerSync {
                 pagesFetched += 1
-                let page = try await api.history(since: bookmark, limit: Self.pageSize)
+                let page = try await api.history(ack: ack, limit: Self.pageSize)
                 if page.messages.isEmpty { break }
 
                 let insertedBefore = newMessages
-                var ackable = bookmark
+                var ackable = ack
                 var blocked = false
                 for row in page.messages {
                     switch ingest(row) {
@@ -87,15 +83,16 @@ final class SyncEngine {
                 }
 
                 let arrived = newMessages > insertedBefore
-                let advanced = ackable > bookmark
-                if advanced { bookmark = ackable }
                 try withAnimation(arrived && !Theme.reduceMotion ? Theme.reveal : nil) {
                     try context.save()
                 }
 
-                guard advanced else { break pages }
-                if blocked { break pages }
-                if page.messages.count < Self.pageSize { break }
+                guard ackable > ack else { break pages }
+                ack = ackable
+            }
+            if !state.hasSynced {
+                state.hasSynced = true
+                try context.save()
             }
         } catch {
             log.error("sync failed: \(String(describing: error), privacy: .private)")

--- a/apps/app/Shared/Store/SyncState.swift
+++ b/apps/app/Shared/Store/SyncState.swift
@@ -3,11 +3,11 @@ import SwiftData
 
 @Model
 final class SyncState {
-    var bookmark: Int
+    var hasSynced: Bool = false
     var failureFirstSeen: [String: Double]
 
-    init(bookmark: Int = 0, failureFirstSeen: [String: Double] = [:]) {
-        self.bookmark = bookmark
+    init(hasSynced: Bool = false, failureFirstSeen: [String: Double] = [:]) {
+        self.hasSynced = hasSynced
         self.failureFirstSeen = failureFirstSeen
     }
 }

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -132,7 +132,7 @@ export const updateDeviceSettingsBody = z.strictObject({
 export type UpdateDeviceSettingsBody = z.infer<typeof updateDeviceSettingsBody>;
 
 export const historyQuery = z.object({
-  since: z.coerce.number().int().nonnegative().optional(),
+  ack: z.coerce.number().int().nonnegative().optional(),
   limit: z.coerce.number().int().min(1).max(200).optional(),
 });
 export type HistoryQuery = z.infer<typeof historyQuery>;


### PR DESCRIPTION
/history filtered on a cursor the client asserted and stored it with no ceiling, so a cursor carried over from a previous identity left three production devices polling for sequence numbers they had never reached and receiving nothing. The read is now unconditional and the client sends an explicit ack, honoured only within 1..seq_counter and otherwise ignored, so a stale value can neither delay nor delete anything. The app stops persisting a bookmark and keeps only a hasSynced flag; existing stores migrate automatically (tested against an old-schema store), and the first sync after updating announces nothing, once. Merging deploys the server half, which heals delivery for the stranded devices on their next poll; the app half ships with the next tag and restores acking for them.