### PR TITLE
Link the Mac App Store from the site, below the DMG

### DIFF
--- a/apps/api/public/faq.html
+++ b/apps/api/public/faq.html
@@ -314,7 +314,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
     <h3>Which devices does it run on?</h3>
     <p>iPhone and iPad on iOS 17 or later, and Mac on macOS 14 or later, where it lives in the menu bar. There is no Android app, because delivery goes through Apple’s push service.</p>
     <h3>Where do I get the Mac app?</h3>
-    <p>From this site, as a notarized DMG. It is not on the App Store, and it updates itself.</p>
+    <p>From this site, as a notarized DMG that updates itself, or from the <a href="https://apps.apple.com/app/id1563961135?platform=mac">Mac App Store</a>. Both are the same app.</p>
     <h3>Can I send to more than one device?</h3>
     <p>Yes, by creating a key on each. A key delivers only to the device that created it, so which key a script holds decides where its notifications land.</p>
     <h3>How do I revoke a key?</h3>

--- a/apps/api/public/faq.md
+++ b/apps/api/public/faq.md
@@ -85,7 +85,7 @@ iPhone and iPad on iOS 17 or later, and Mac on macOS 14 or later, where it lives
 
 ### Where do I get the Mac app?
 
-From this site, as a notarized DMG. It is not on the App Store, and it updates itself.
+From this site, as a notarized DMG that updates itself, or from the [Mac App Store](https://apps.apple.com/app/id1563961135?platform=mac). Both are the same app.
 
 ### Can I send to more than one device?
 

--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1943,7 +1943,7 @@ spec:
       <p class="meta reqs">iOS 17 or later. macOS 14 or later, on Apple silicon or a T2 Mac.</p>
     </div>
 
-    <p class="meta brew-lead"><a href="https://brew.sh" class="src">Homebrew</a> works too:</p>
+    <p class="meta brew-lead">Also on the <a href="https://apps.apple.com/app/id1563961135?platform=mac" class="src">Mac App Store</a>, or with <a href="https://brew.sh" class="src">Homebrew</a>:</p>
     <div class="term term-brew">
       <div class="term-bar">
         <span class="dot3"><i></i><i></i><i></i></span>

--- a/apps/api/public/index.md
+++ b/apps/api/public/index.md
@@ -29,7 +29,8 @@ best-effort.
 
 1. Install the app: [iPhone and iPad](https://apps.apple.com/app/id1563961135)
    (iOS 17 or later) or [Mac](https://notifi.it/download/mac) (macOS 14 or
-   later, also `brew install --cask notifi-it/tap/notifi`).
+   later; also on the [Mac App Store](https://apps.apple.com/app/id1563961135?platform=mac)
+   and as `brew install --cask notifi-it/tap/notifi`).
 2. Allow notifications when the app asks.
 3. Open the Keys tab, pick `Device`, press **Copy key**. It starts with `nk_`.
 4. Send something:

--- a/apps/api/public/terms.html
+++ b/apps/api/public/terms.html
@@ -300,7 +300,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 
   <section>
     <h2>The apps</h2>
-    <p>The iPhone app is distributed through the App Store, where Apple’s own terms also apply. The Mac app is distributed from this site and updates itself. The source code for the apps and the service is public at <a href="https://github.com/notifi-it/notifi">github.com/notifi-it/notifi</a>, under the licence stated there.</p>
+    <p>The iPhone app is distributed through the App Store, where Apple’s own terms also apply. The Mac app is distributed from this site, where it updates itself, and through the Mac App Store, where Apple’s terms apply as well. The source code for the apps and the service is public at <a href="https://github.com/notifi-it/notifi">github.com/notifi-it/notifi</a>, under the licence stated there.</p>
   </section>
 
   <section>

--- a/apps/api/public/terms.md
+++ b/apps/api/public/terms.md
@@ -40,7 +40,7 @@ These terms are governed by the law of England and Wales. If you are a consumer,
 
 ## The apps
 
-The iPhone app is distributed through the App Store, where Apple’s own terms also apply. The Mac app is distributed from this site and updates itself. The source code for the apps and the service is public at [github.com/notifi-it/notifi](https://github.com/notifi-it/notifi), under the licence stated there.
+The iPhone app is distributed through the App Store, where Apple’s own terms also apply. The Mac app is distributed from this site, where it updates itself, and through the Mac App Store, where Apple’s terms apply as well. The source code for the apps and the service is public at [github.com/notifi-it/notifi](https://github.com/notifi-it/notifi), under the licence stated there.
 
 ## Changes and contact
 

--- a/packages/site/pages/faq.md
+++ b/packages/site/pages/faq.md
@@ -93,7 +93,7 @@ iPhone and iPad on iOS 17 or later, and Mac on macOS 14 or later, where it lives
 
 ### Where do I get the Mac app?
 
-From this site, as a notarized DMG. It is not on the App Store, and it updates itself.
+From this site, as a notarized DMG that updates itself, or from the [Mac App Store](https://apps.apple.com/app/id1563961135?platform=mac). Both are the same app.
 
 ### Can I send to more than one device?
 

--- a/packages/site/pages/terms.md
+++ b/packages/site/pages/terms.md
@@ -48,7 +48,7 @@ These terms are governed by the law of England and Wales. If you are a consumer,
 
 ## The apps
 
-The iPhone app is distributed through the App Store, where Apple’s own terms also apply. The Mac app is distributed from this site and updates itself. The source code for the apps and the service is public at [github.com/notifi-it/notifi](https://github.com/notifi-it/notifi), under the licence stated there.
+The iPhone app is distributed through the App Store, where Apple’s own terms also apply. The Mac app is distributed from this site, where it updates itself, and through the Mac App Store, where Apple’s terms apply as well. The source code for the apps and the service is public at [github.com/notifi-it/notifi](https://github.com/notifi-it/notifi), under the licence stated there.
 
 ## Changes and contact
 


### PR DESCRIPTION
The Mac app is on the Mac App Store, but the site still said it was not and only offered the DMG. The download section now names the store next to Homebrew, and the FAQ, terms and Markdown pages say the same. The DMG stays the main macOS download button.

![Download section](https://github.com/user-attachments/assets/86a29b8a-c89c-419f-8e06-2b3a8c42b9a4)