### PR TITLE
Refuse sends to a device with 500 uncollected notifications

### DIFF
--- a/apps/api/public/docs.html
+++ b/apps/api/public/docs.html
@@ -618,6 +618,7 @@ Accept-Language: en-GB
       <button class="tab" role="tab" aria-selected="false" aria-controls="r-p-401" id="r-t-401"><span>401</span></button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="r-p-422" id="r-t-422"><span>422</span></button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="r-p-429" id="r-t-429"><span>429</span></button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="r-p-429" id="r-t-429"><span>429</span></button>
     </div>
 
     <div class="term">
@@ -656,6 +657,12 @@ Content-Type<span class="f">:</span> <span class="s">application/json; charset=u
 Retry-After<span class="f">:</span> <span class="s">42</span>
 
 {<span class="s">&quot;error&quot;</span>:{<span class="s">&quot;code&quot;</span>:<span class="s">&quot;rate_limited&quot;</span>,<span class="s">&quot;message&quot;</span>:<span class="s">&quot;Too many notifications. Try again shortly.&quot;</span>}}</pre>
+      </div>
+      <div class="panel" id="r-p-429" role="tabpanel" tabindex="0" aria-labelledby="r-t-429" data-name="uncollected_limit" data-label="429" hidden>
+<pre><span class="f">HTTP</span>/<span class="n">1.1</span> <span class="n">429</span> <span class="s">Too Many Requests</span>
+Content-Type<span class="f">:</span> <span class="s">application/json; charset=utf-8</span>
+
+{<span class="s">&quot;error&quot;</span>:{<span class="s">&quot;code&quot;</span>:<span class="s">&quot;uncollected_limit&quot;</span>,<span class="s">&quot;message&quot;</span>:<span class="s">&quot;Not sent. This device has too many uncollected notifications. New ones are accepted once it collects.&quot;</span>}}</pre>
       </div>
     </div>
     <p>
@@ -740,6 +747,11 @@ Content-Type: application/json; charset=utf-8
             <td>Over the hourly device limit or the per-minute IP limit. Carries a Retry-After header with the seconds until the window resets.</td>
           </tr>
           <tr>
+            <td><code>429</code></td>
+            <td><code>uncollected_limit</code></td>
+            <td>The device has 500 uncollected notifications. No Retry-After: the limit clears when the device next collects, not with time. Open the app on the device.</td>
+          </tr>
+          <tr>
             <td><code>404</code></td>
             <td><code>not_found</code></td>
             <td>No such path.</td>
@@ -760,6 +772,7 @@ Content-Type: application/json; charset=utf-8
       <li>60 notifications an hour per device, shared across every key on it.</li>
       <li>5 active send keys per device, one of which is the app’s own device key.</li>
       <li>100 requests a minute per IP address, across every endpoint.</li>
+      <li>500 uncollected notifications per device. Once that many sit waiting, sends are refused until the device collects them.</li>
       <li>Revoking a key in the app takes effect on the next send. Reinstalling the app, or moving to a new device, makes a new identity and every old key stops working; there is no migration.</li>
     </ul>
     <p>

--- a/apps/api/public/docs.md
+++ b/apps/api/public/docs.md
@@ -104,6 +104,15 @@ Retry-After: 42
 {"error":{"code":"rate_limited","message":"Too many notifications. Try again shortly."}}
 ```
 
+### 429
+
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json; charset=utf-8
+
+{"error":{"code":"uncollected_limit","message":"Not sent. This device has too many uncollected notifications. New ones are accepted once it collects."}}
+```
+
 A `warnings` array is present only when the notification was delivered differently from what was asked: a cropped title or body, or a critical alert delivered as an ordinary notification. The status is still `202`; the notification was sent, in the altered form each warning describes.
 
 ```http
@@ -147,6 +156,7 @@ Every error nests the code one level down. Read `error.code`, not `code`. The `m
 | `401` | `unknown_key` | The key is unknown or has been revoked. |
 | `422` | `invalid_content` | The device is set to refuse a notification it cannot deliver as written. |
 | `429` | `rate_limited` | Over the hourly device limit or the per-minute IP limit. Carries a Retry-After header with the seconds until the window resets. |
+| `429` | `uncollected_limit` | The device has 500 uncollected notifications. No Retry-After: the limit clears when the device next collects, not with time. Open the app on the device. |
 | `404` | `not_found` | No such path. |
 | `500` | `internal_error` | Something broke on our side. |
 
@@ -155,6 +165,7 @@ Every error nests the code one level down. Read `error.code`, not `code`. The `m
 - 60 notifications an hour per device, shared across every key on it.
 - 5 active send keys per device, one of which is the app’s own device key.
 - 100 requests a minute per IP address, across every endpoint.
+- 500 uncollected notifications per device. Once that many sit waiting, sends are refused until the device collects them.
 - Revoking a key in the app takes effect on the next send. Reinstalling the app, or moving to a new device, makes a new identity and every old key stops working; there is no migration.
 
 A `429` carries `Retry-After` in seconds. The device limit is 60 an hour across all 5 keys; the address limit is 100 requests a minute and covers every endpoint.

--- a/apps/api/public/openapi.json
+++ b/apps/api/public/openapi.json
@@ -360,6 +360,7 @@
                 "enum": [
                   "unknown_key",
                   "rate_limited",
+                  "uncollected_limit",
                   "invalid_request",
                   "invalid_content",
                   "not_found",
@@ -403,7 +404,7 @@
         }
       },
       "UnexpectedError": {
-        "description": "Any other failure, in the same error shape: not_found or internal_error.",
+        "description": "Any other failure, in the same error shape: uncollected_limit or not_found or internal_error.",
         "content": {
           "application/json": {
             "schema": {

--- a/apps/api/src/routes/send.ts
+++ b/apps/api/src/routes/send.ts
@@ -4,6 +4,7 @@ import {
   OCCURRED_AT_MAX_SKEW_MS,
   sendParams,
   TITLE_MAX,
+  UNCOLLECTED_MAX,
 } from '@notifi/contract';
 import { copyFor, fmt, SOURCE_LANGUAGE, type Strings } from '@notifi/copy';
 import { Hono } from 'hono';
@@ -29,6 +30,8 @@ interface KeyDeviceRow {
   revoked_at: number | null;
   is_critical: number;
   device_id: number;
+  seq_counter: number;
+  acked_id: number;
   apns_token: string;
   encryption_public_key: string;
   strict_send: number;
@@ -118,7 +121,8 @@ send.on(['GET', 'POST'], '/send', async (c) => {
   const secretHash = await hashKey(input.key);
   const row = await c.env.DB.prepare(
     `SELECT k.id AS key_id, k.revoked_at AS revoked_at, k.is_critical AS is_critical,
-            d.id AS device_id, d.apns_token AS apns_token,
+            d.id AS device_id, d.seq_counter AS seq_counter, d.acked_id AS acked_id,
+            d.apns_token AS apns_token,
             d.encryption_public_key AS encryption_public_key,
             d.strict_send AS strict_send
      FROM keys k JOIN devices d ON d.id = k.device_id
@@ -129,6 +133,10 @@ send.on(['GET', 'POST'], '/send', async (c) => {
 
   if (!row || row.revoked_at !== null) {
     return c.json(errBody('unknown_key', t(c).api.unknownKey), 401);
+  }
+
+  if (row.seq_counter - row.acked_id >= UNCOLLECTED_MAX) {
+    return c.json(errBody('uncollected_limit', t(c).api.uncollectedLimit), 429);
   }
 
   const w = windowStart(nowS);

--- a/packages/apidoc/src/spec.ts
+++ b/packages/apidoc/src/spec.ts
@@ -1,5 +1,5 @@
 import type { PublicErrorCode } from '@notifi/contract';
-import { IMAGE_URL_MAX, LINK_URL_MAX, MESSAGE_MAX, TITLE_MAX } from '@notifi/contract';
+import { IMAGE_URL_MAX, LINK_URL_MAX, MESSAGE_MAX, TITLE_MAX, UNCOLLECTED_MAX } from '@notifi/contract';
 import type { Lang } from './shikify.js';
 
 export { IMAGE_URL_MAX, LINK_URL_MAX, MESSAGE_MAX, TITLE_MAX };
@@ -175,6 +175,14 @@ export const errors: ErrorRow[] = [
     summary: 'Over the hourly device limit or the per-minute IP limit.',
     detail: 'Carries a Retry-After header with the seconds until the window resets.',
   },
+  {
+    code: 'uncollected_limit',
+    status: 429,
+    reason: 'Too Many Requests',
+    message: 'Not sent. This device has too many uncollected notifications. New ones are accepted once it collects.',
+    summary: `The device has ${UNCOLLECTED_MAX} uncollected notifications.`,
+    detail: 'No Retry-After: the limit clears when the device next collects, not with time. Open the app on the device.',
+  },
   { code: 'not_found', status: 404, reason: 'Not Found', message: 'No such path.', summary: 'No such path.', detail: '' },
   {
     code: 'internal_error',
@@ -190,10 +198,11 @@ export const limits: string[] = [
   `${SENDS_PER_HOUR} notifications an hour per device, shared across every key on it.`,
   `${KEYS_PER_DEVICE} active send keys per device, one of which is the app’s own device key.`,
   `${REQUESTS_PER_MINUTE} requests a minute per IP address, across every endpoint.`,
+  `${UNCOLLECTED_MAX} uncollected notifications per device. Once that many sit waiting, sends are refused until the device collects them.`,
   'Revoking a key in the app takes effect on the next send. Reinstalling the app, or moving to a new device, makes a new identity and every old key stops working; there is no migration.',
 ];
 
-export const OPERATION_ERRORS = ['invalid_request', 'unknown_key', 'invalid_content', 'rate_limited'];
+export const OPERATION_ERRORS = ['invalid_request', 'unknown_key', 'invalid_content', 'rate_limited', 'uncollected_limit'];
 
 export const INTEGRATION_SURFACE =
   'There is no MCP server, no webhook API and no OAuth. One endpoint and a bearer token is the whole integration surface. Anything claiming otherwise is not notifi.';

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -6,6 +6,7 @@ export const errorCode = z.enum([
   'unknown_device',
   'unknown_key',
   'rate_limited',
+  'uncollected_limit',
   'invalid_request',
   'invalid_content',
   'not_found',
@@ -27,6 +28,8 @@ export const apiError = z.object({
   }),
 });
 export type ApiError = z.infer<typeof apiError>;
+
+export const UNCOLLECTED_MAX = 500;
 
 export const OCCURRED_AT_MIN_MS = 946_684_800_000;
 export const OCCURRED_AT_MAX_SKEW_MS = 24 * 60 * 60 * 1000;

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -11,6 +11,8 @@ export const copy = {
 
     rateLimitedIP: 'Too many requests from this IP.',
     rateLimitedAccount: 'Rate limit exceeded. Too many notifications this hour.',
+    uncollectedLimit:
+      'Not sent. This device has too many uncollected notifications. New ones are accepted once it collects.',
 
     badSignature: 'Invalid request signature.',
     staleTimestamp: 'Request timestamp is outside the allowed window.',

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -6,6 +6,8 @@ export const de: Translation = {
 
   'api.rateLimitedIP': 'Zu viele Anfragen von dieser IP.',
   'api.rateLimitedAccount': 'Limit erreicht. Zu viele Benachrichtigungen in dieser Stunde.',
+  'api.uncollectedLimit':
+    'Nicht gesendet. Dieses Gerät hat zu viele nicht abgeholte Benachrichtigungen. Neue werden angenommen, sobald es sie abholt.',
 
   'api.badSignature': 'Ungültige Anfragesignatur.',
   'api.staleTimestamp': 'Der Zeitstempel der Anfrage liegt außerhalb des zulässigen Fensters.',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -6,6 +6,8 @@ export const es: Translation = {
 
   'api.rateLimitedIP': 'Demasiadas solicitudes desde esta IP.',
   'api.rateLimitedAccount': 'Límite de solicitudes superado. Demasiadas notificaciones esta hora.',
+  'api.uncollectedLimit':
+    'No enviado. Este dispositivo tiene demasiadas notificaciones sin recoger. Se aceptarán nuevas cuando las recoja.',
 
   'api.badSignature': 'Firma de solicitud no válida.',
   'api.staleTimestamp': 'La marca de tiempo de la solicitud está fuera del margen permitido.',

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -6,6 +6,8 @@ export const fr: Translation = {
 
   'api.rateLimitedIP': 'Trop de requêtes depuis cette adresse IP.',
   'api.rateLimitedAccount': 'Limite de débit dépassée. Trop de notifications cette heure-ci.',
+  'api.uncollectedLimit':
+    'Non envoyé. Cet appareil a trop de notifications non relevées. De nouvelles seront acceptées dès qu’il les relève.',
 
   'api.badSignature': 'Signature de requête invalide.',
   'api.staleTimestamp': "L’horodatage de la requête est hors de la fenêtre autorisée.",

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -6,6 +6,8 @@ export const it: Translation = {
 
   'api.rateLimitedIP': 'Troppe richieste da questo IP.',
   'api.rateLimitedAccount': 'Limite superato. Troppe notifiche in questa ora.',
+  'api.uncollectedLimit':
+    'Non inviato. Questo dispositivo ha troppe notifiche non ritirate. Le nuove saranno accettate quando le ritira.',
 
   'api.badSignature': 'Firma della richiesta non valida.',
   'api.staleTimestamp': 'Il timestamp della richiesta è fuori dalla finestra consentita.',


### PR DESCRIPTION
A key paging a device that never collects can run indefinitely: one cron sent 1,671 notifications over 23 hours to a device last seen two weeks earlier, and the hourly limit never fired because 60 an hour is exactly what a once-a-minute job produces. /send now answers 429 uncollected_limit once a device's backlog reaches UNCOLLECTED_MAX (500), with no Retry-After since the limit clears when the device collects rather than with time. No device is near the cap today. The four translations of the new API string were not written by a native speaker.