### PR TITLE
Count sends in Analytics Engine, not the messages table

### DIFF
--- a/apps/api/public/privacy.html
+++ b/apps/api/public/privacy.html
@@ -253,7 +253,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
   <p class="eyebrow">Privacy</p>
   <h1>Privacy policy</h1>
   <p class="lede">This describes what notifi stores, how long it keeps it, what the server can and cannot read, and what the person sending you a notification can learn about you.</p>
-  <p class="meta">Last updated 29 August 2026</p>
+  <p class="meta">Last updated 6 September 2026</p>
 
   <section>
     <h2>Who runs notifi</h2>
@@ -315,6 +315,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
       <li><strong>Uncollected notifications</strong> are kept, encrypted, until your device collects them, for at most 90 days. A daily job removes anything older.</li>
       <li><strong>Devices</strong> are kept as long as they are registered. When Apple’s push service reports that the app has been removed from a device, the next send to it deletes the registration and everything under it — keys and uncollected notifications included. A device that is never sent to again can keep its row until a deletion request removes it; email <a href="mailto:hello@notifi.it">hello@notifi.it</a> with the device’s public key.</li>
       <li><strong>Send keys</strong> are kept while the device exists, including revoked ones, so that a revoked key cannot be reused.</li>
+      <li><strong>A record of each send</strong> — which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes — is kept for three months in Cloudflare’s analytics store, to count sends and to notice failed deliveries. It holds no content and no IP address.</li>
     </ul>
     <p>notifi is a relay, not a mailbox. Once your device has a notification, the server copy is gone and the only copy is the one on your device.</p>
   </section>

--- a/apps/api/public/privacy.md
+++ b/apps/api/public/privacy.md
@@ -2,7 +2,7 @@
 
 > This describes what notifi stores, how long it keeps it, what the server can and cannot read, and what the person sending you a notification can learn about you.
 
-_Last updated 29 August 2026_
+_Last updated 6 September 2026_
 
 ## Who runs notifi
 
@@ -59,6 +59,7 @@ Because the sender and the recipient both talk to the same server, that server i
 - **Uncollected notifications** are kept, encrypted, until your device collects them, for at most 90 days. A daily job removes anything older.
 - **Devices** are kept as long as they are registered. When Apple’s push service reports that the app has been removed from a device, the next send to it deletes the registration and everything under it — keys and uncollected notifications included. A device that is never sent to again can keep its row until a deletion request removes it; email [hello@notifi.it](mailto:hello@notifi.it) with the device’s public key.
 - **Send keys** are kept while the device exists, including revoked ones, so that a revoked key cannot be reused.
+- **A record of each send** — which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes — is kept for three months in Cloudflare’s analytics store, to count sends and to notice failed deliveries. It holds no content and no IP address.
 
 notifi is a relay, not a mailbox. Once your device has a notification, the server copy is gone and the only copy is the one on your device.
 

--- a/apps/api/scripts/daily_summary.py
+++ b/apps/api/scripts/daily_summary.py
@@ -16,6 +16,7 @@ D1_QUERY = (
     "https://api.cloudflare.com/client/v4/accounts/{account}/d1/database/{database}/query"
 )
 CF_GRAPHQL = "https://api.cloudflare.com/client/v4/graphql"
+AE_SQL = "https://api.cloudflare.com/client/v4/accounts/{account}/analytics_engine/sql"
 FIRST_INSTALL = {"1", "1F"}
 WEEK = 604800
 SESSION = requests.Session()
@@ -81,6 +82,22 @@ def query_production_d1(sql):
     if not body["success"]:
         raise SystemExit(f"D1 query failed: {body['errors']}")
     return body["result"][0]["results"][0]
+
+
+def query_send_events(sql):
+    # Sends are counted from Analytics Engine, not from the messages table: a
+    # collected notification is deleted from messages, so that table only ever
+    # holds what is still waiting. Rows may be sampled at volume, so counts are
+    # SUM(_sample_interval) rather than COUNT().
+    res = SESSION.post(
+        AE_SQL.format(account=os.environ["CLOUDFLARE_ACCOUNT_ID"]),
+        headers={"Authorization": f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}"},
+        data=sql,
+        timeout=30,
+    )
+    res.raise_for_status()
+    rows = res.json()["data"]
+    return rows[0] if rows else {}
 
 
 def senders(count):
@@ -184,19 +201,29 @@ def compose_notification():
     downloads_week = sum(n for n, _ in reports[:7] if n is not None)
     downloads_prior = sum(n for n, _ in reports[7:] if n is not None)
 
-    day = query_production_d1(
-        "SELECT COUNT(*) AS sends, COUNT(DISTINCT device_id) AS senders"
-        " FROM messages WHERE created_at >= unixepoch()-86400"
-    )
-    week = query_production_d1(
-        "SELECT COUNT(*) AS sends, COUNT(DISTINCT device_id) AS senders"
-        " FROM messages WHERE created_at >= unixepoch()-604800"
-    )
-    prior = query_production_d1(
-        "SELECT COUNT(*) AS sends FROM messages"
-        " WHERE created_at >= unixepoch()-1209600 AND created_at < unixepoch()-604800"
-    )
-    history = query_production_d1("SELECT MIN(created_at) AS oldest FROM messages")
+    def sends_since(days, until_days=0):
+        row = query_send_events(
+            "SELECT SUM(_sample_interval) AS sends,"
+            " COUNT(DISTINCT index1) AS senders,"
+            " SUM(IF(blob2 = 'failed', _sample_interval, 0)) AS failed"
+            f" FROM notifi_sends WHERE timestamp >= NOW() - INTERVAL '{days}' DAY"
+            + (f" AND timestamp < NOW() - INTERVAL '{until_days}' DAY" if until_days else "")
+        )
+        return {
+            "sends": int(row.get("sends") or 0),
+            "senders": int(row.get("senders") or 0),
+            "failed": int(row.get("failed") or 0),
+        }
+
+    day = sends_since(1)
+    week = sends_since(7)
+    prior = sends_since(14, 7)
+    oldest = query_send_events("SELECT MIN(timestamp) AS oldest FROM notifi_sends").get("oldest")
+    history = {
+        "oldest": int(datetime.fromisoformat(oldest).replace(tzinfo=timezone.utc).timestamp())
+        if oldest
+        else None
+    }
     devices = query_production_d1(
         "SELECT COUNT(*) AS total,"
         " SUM(CASE WHEN created_at >= unixepoch()-86400 THEN 1 ELSE 0 END) AS day,"
@@ -241,7 +268,8 @@ def compose_notification():
         f"**{day['sends']}** send{'' if day['sends'] == 1 else 's'} yesterday.",
         "",
         "**Yesterday**",
-        f"- Sends **{day['sends']}** from {senders(day['senders'])}",
+        f"- Sends **{day['sends']}** from {senders(day['senders'])}"
+        + (f" · **{day['failed']}** failed to push" if day["failed"] else ""),
         downloads_line,
         f"- Devices **+{devices['day']}**",
         f"- Site **{humans_yday}** measured humans · {site_yday_u} IPs · {site_yday_v} loads",

--- a/apps/api/src/routes/send.ts
+++ b/apps/api/src/routes/send.ts
@@ -286,6 +286,12 @@ send.on(['GET', 'POST'], '/send', async (c) => {
     nowS,
     String(messageId),
   );
+  c.env.SEND_EVENTS.writeDataPoint({
+    indexes: [String(row.device_id)],
+    blobs: [String(row.key_id), pushed ? 'pushed' : 'failed', critical ? 'critical' : 'normal'],
+    doubles: [payloadBytes(payload)],
+  });
+
   const wake = (async () => {
     try {
       const id = c.env.DEVICE_SOCKET.idFromName(String(row.device_id));

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -14,6 +14,7 @@ export interface Env {
   DEVICE_SOCKET: DurableObjectNamespace<DeviceSocket>;
   APNS_TOKEN: DurableObjectNamespace<ApnsToken>;
   SEND_IP_LIMIT: RateLimitBinding;
+  SEND_EVENTS: AnalyticsEngineDataset;
   APNS_HOST: string;
   APNS_TOPIC: string;
   APNS_TEAM_ID: string;

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -82,6 +82,14 @@ crons = ["0 4 * * *"]
 enabled = true
 head_sampling_rate = 1
 
+# One data point per accepted send: the device and key, whether the APNs push
+# succeeded, and the payload size. messages is a delivery queue that empties
+# on collect, so it cannot answer "how many were sent yesterday"; this can, for
+# three months, which is what the daily summary and the dashboard chart need.
+[[analytics_engine_datasets]]
+binding = "SEND_EVENTS"
+dataset = "notifi_sends"
+
 [[unsafe.bindings]]
 name = "SEND_IP_LIMIT"
 type = "ratelimit"

--- a/packages/site/pages/privacy.md
+++ b/packages/site/pages/privacy.md
@@ -10,7 +10,7 @@ ogDescription: What notifi stores, for how long, and what it cannot read.
 
 > This describes what notifi stores, how long it keeps it, what the server can and cannot read, and what the person sending you a notification can learn about you.
 
-_Last updated 29 August 2026_
+_Last updated 6 September 2026_
 
 ## Who runs notifi
 
@@ -67,6 +67,7 @@ Because the sender and the recipient both talk to the same server, that server i
 - **Uncollected notifications** are kept, encrypted, until your device collects them, for at most 90 days. A daily job removes anything older.
 - **Devices** are kept as long as they are registered. When Apple’s push service reports that the app has been removed from a device, the next send to it deletes the registration and everything under it — keys and uncollected notifications included. A device that is never sent to again can keep its row until a deletion request removes it; email [hello@notifi.it](mailto:hello@notifi.it) with the device’s public key.
 - **Send keys** are kept while the device exists, including revoked ones, so that a revoked key cannot be reused.
+- **A record of each send** — which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes — is kept for three months in Cloudflare’s analytics store, to count sends and to notice failed deliveries. It holds no content and no IP address.
 
 notifi is a relay, not a mailbox. Once your device has a notification, the server copy is gone and the only copy is the one on your device.
 


### PR DESCRIPTION
history.ts deletes a notification from messages the moment the device collects it, so that table is a queue of what is still waiting, not a log of what was sent, and the daily summary has been reporting the uncollected count as sends. Every accepted send now writes one Analytics Engine data point (device, key, whether the APNs push succeeded, payload size) and the summary reads it back over the SQL API, reporting failed pushes alongside sends; retention is three months, so lifetime totals stay with keys.sent_count. The privacy policy discloses the record. The summary shows zero sends until the Worker has been live for a day, and its query needs CLOUDFLARE_API_TOKEN to carry Account Analytics Read or the next run fails.