### PR TITLE
Ignore __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ apps/app/fastlane/test_output/
 apps/app/fastlane/README.md
 apps/app/vendor/bundle/
 apps/app/.bundle/
+
+# Python
+__pycache__/


### PR DESCRIPTION
#366 untracked the committed .pyc files but the ignore rule that stops them coming back was never staged, so any py_compile run recreates them as untracked files. This adds the three lines that PR was meant to carry.