### PR TITLE
Give the Mac App Store archive a build number

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -229,12 +229,17 @@ jobs:
           CODE_SIGN_STYLE: Manual
           MAC_CODE_SIGN_IDENTITY: Apple Distribution
         run: |
+          # CURRENT_PROJECT_VERSION is CFBundleVersion. Left at project.yml's
+          # "1", every Mac pkg carries the same build number and App Store
+          # Connect refuses the second one for a version. The timestamp is the
+          # same scheme the Fastfile's build_number uses for iOS and the DMG.
           xcodebuild archive \
             -scheme notifi-macOS-AppStore \
             -destination 'generic/platform=macOS' \
             -archivePath "$RUNNER_TEMP/notifi-macOS-AppStore.xcarchive" \
             DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
-            MARKETING_VERSION="$MARKETING_VERSION"
+            MARKETING_VERSION="$MARKETING_VERSION" \
+            CURRENT_PROJECT_VERSION="$(date -u +%Y%m%d%H%M)"
           xcodebuild -exportArchive \
             -archivePath "$RUNNER_TEMP/notifi-macOS-AppStore.xcarchive" \
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions-mas.plist" \


### PR DESCRIPTION
The mac-app-store job archives with xcodebuild directly and never set CURRENT_PROJECT_VERSION, so every pkg carried CFBundleVersion 1 and App Store Connect refused the 2.0.20 upload as not higher than the previous one. This stamps the same YYYYMMDDHHMM build number the Fastfile already uses for iOS and the DMG. 2.0.20 itself was submitted from the local lane, which has always done this.