### PR TITLE
Count collections alongside sends

### DIFF
--- a/apps/api/public/privacy.html
+++ b/apps/api/public/privacy.html
@@ -315,7 +315,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
       <li><strong>Uncollected notifications</strong> are kept, encrypted, until your device collects them, for at most 90 days. A daily job removes anything older.</li>
       <li><strong>Devices</strong> are kept as long as they are registered. When Apple’s push service reports that the app has been removed from a device, the next send to it deletes the registration and everything under it — keys and uncollected notifications included. A device that is never sent to again can keep its row until a deletion request removes it; email <a href="mailto:hello@notifi.it">hello@notifi.it</a> with the device’s public key.</li>
       <li><strong>Send keys</strong> are kept while the device exists, including revoked ones, so that a revoked key cannot be reused.</li>
-      <li><strong>A record of each send</strong> — which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes — is kept for three months in Cloudflare’s analytics store, to count sends and to notice failed deliveries. It holds no content and no IP address.</li>
+      <li><strong>A record of each send and each collection</strong> — for a send, which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes; for a collection, which device and how many notifications it took — is kept for three months in Cloudflare’s analytics store, to count sends and collections and to notice failed deliveries. It holds no content and no IP address.</li>
     </ul>
     <p>notifi is a relay, not a mailbox. Once your device has a notification, the server copy is gone and the only copy is the one on your device.</p>
   </section>

--- a/apps/api/public/privacy.md
+++ b/apps/api/public/privacy.md
@@ -59,7 +59,7 @@ Because the sender and the recipient both talk to the same server, that server i
 - **Uncollected notifications** are kept, encrypted, until your device collects them, for at most 90 days. A daily job removes anything older.
 - **Devices** are kept as long as they are registered. When Apple’s push service reports that the app has been removed from a device, the next send to it deletes the registration and everything under it — keys and uncollected notifications included. A device that is never sent to again can keep its row until a deletion request removes it; email [hello@notifi.it](mailto:hello@notifi.it) with the device’s public key.
 - **Send keys** are kept while the device exists, including revoked ones, so that a revoked key cannot be reused.
-- **A record of each send** — which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes — is kept for three months in Cloudflare’s analytics store, to count sends and to notice failed deliveries. It holds no content and no IP address.
+- **A record of each send and each collection** — for a send, which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes; for a collection, which device and how many notifications it took — is kept for three months in Cloudflare’s analytics store, to count sends and collections and to notice failed deliveries. It holds no content and no IP address.
 
 notifi is a relay, not a mailbox. Once your device has a notification, the server copy is gone and the only copy is the one on your device.
 

--- a/apps/api/scripts/daily_summary.py
+++ b/apps/api/scripts/daily_summary.py
@@ -226,9 +226,22 @@ def compose_notification():
             "failed": int(row.get("failed") or 0),
         }
 
+    def collected_since(days):
+        row = query_send_events(
+            "SELECT SUM(_sample_interval * double1) AS collected,"
+            " COUNT(DISTINCT index1) AS collectors"
+            f" FROM notifi_collects WHERE timestamp >= NOW() - INTERVAL '{days}' DAY"
+        )
+        return {
+            "collected": int(row.get("collected") or 0),
+            "collectors": int(row.get("collectors") or 0),
+        }
+
     day = sends_since(1)
     week = sends_since(7)
     prior = sends_since(14, 7)
+    day_collected = collected_since(1)
+    week_collected = collected_since(7)
     oldest = query_send_events("SELECT MIN(timestamp) AS oldest FROM notifi_sends").get("oldest")
     history = {
         "oldest": int(datetime.fromisoformat(oldest).replace(tzinfo=timezone.utc).timestamp())
@@ -284,12 +297,14 @@ def compose_notification():
         "**Yesterday**",
         f"- Sends **{day['sends']}** from {senders(day['senders'])}"
         + (f" · **{day['failed']}** failed to push" if day["failed"] else ""),
+        f"- Collected **{day_collected['collected']}** by {senders(day_collected['collectors'])}",
         downloads_line,
         f"- Devices **+{devices['day']}**",
         f"- Site **{humans_yday}** measured humans · {site_yday_u} IPs · {site_yday_v} loads",
         "",
         "**This week**",
         sends_week,
+        f"- Collected **{week_collected['collected']}** by {senders(week_collected['collectors'])}",
         f"- Downloads **{downloads_week}** · {split(week_platforms)}"
         f" ({week_on_week(downloads_week, downloads_prior)} vs prior 7d)",
         f"- Site **{humans_wk}** measured humans ({week_on_week(humans_wk, humans_prior)} vs prior 7d)"

--- a/apps/api/src/routes/history.ts
+++ b/apps/api/src/routes/history.ts
@@ -22,7 +22,7 @@ history.get('/history', async (c) => {
   const limit = parsed.data.limit ?? 50;
 
   if (ack > 0 && ack <= device.seq_counter) {
-    await c.env.DB.batch([
+    const [, deleted] = await c.env.DB.batch([
       c.env.DB.prepare(
         'UPDATE devices SET acked_id = MAX(acked_id, ?), last_seen_at = ? WHERE id = ?',
       ).bind(ack, nowS, device.id),
@@ -31,6 +31,13 @@ history.get('/history', async (c) => {
         ack,
       ),
     ]);
+    const collected = deleted?.meta.changes ?? 0;
+    if (collected > 0) {
+      c.env.COLLECT_EVENTS.writeDataPoint({
+        indexes: [String(device.id)],
+        doubles: [collected],
+      });
+    }
   }
 
   const rows = await c.env.DB.prepare(

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -15,6 +15,7 @@ export interface Env {
   APNS_TOKEN: DurableObjectNamespace<ApnsToken>;
   SEND_IP_LIMIT: RateLimitBinding;
   SEND_EVENTS: AnalyticsEngineDataset;
+  COLLECT_EVENTS: AnalyticsEngineDataset;
   APNS_HOST: string;
   APNS_TOPIC: string;
   APNS_TEAM_ID: string;

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -90,6 +90,13 @@ head_sampling_rate = 1
 binding = "SEND_EVENTS"
 dataset = "notifi_sends"
 
+# One data point per collection that removed something: the device and how
+# many notifications it took. Counted from the rows the DELETE removed, not
+# from acked_id, which a stale client cursor could once inflate.
+[[analytics_engine_datasets]]
+binding = "COLLECT_EVENTS"
+dataset = "notifi_collects"
+
 [[unsafe.bindings]]
 name = "SEND_IP_LIMIT"
 type = "ratelimit"

--- a/packages/site/pages/privacy.md
+++ b/packages/site/pages/privacy.md
@@ -67,7 +67,7 @@ Because the sender and the recipient both talk to the same server, that server i
 - **Uncollected notifications** are kept, encrypted, until your device collects them, for at most 90 days. A daily job removes anything older.
 - **Devices** are kept as long as they are registered. When Apple’s push service reports that the app has been removed from a device, the next send to it deletes the registration and everything under it — keys and uncollected notifications included. A device that is never sent to again can keep its row until a deletion request removes it; email [hello@notifi.it](mailto:hello@notifi.it) with the device’s public key.
 - **Send keys** are kept while the device exists, including revoked ones, so that a revoked key cannot be reused.
-- **A record of each send** — which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes — is kept for three months in Cloudflare’s analytics store, to count sends and to notice failed deliveries. It holds no content and no IP address.
+- **A record of each send and each collection** — for a send, which device and key it went to, whether the push to Apple succeeded, and the size of the notification in bytes; for a collection, which device and how many notifications it took — is kept for three months in Cloudflare’s analytics store, to count sends and collections and to notice failed deliveries. It holds no content and no IP address.
 
 notifi is a relay, not a mailbox. Once your device has a notification, the server copy is gone and the only copy is the one on your device.
 


### PR DESCRIPTION
Each ack in /history that removes rows now writes an Analytics Engine data point with the device and the number of notifications it took, using the DELETE's own row count rather than a difference of acked_id, which several devices still carry inflated from the bug history-ack fixed. The daily summary reports Collected beside Sends for yesterday and the week, and the privacy policy's analytics bullet now covers collections too.