### PR TITLE
Mac: a reading window opened from the menu bar

### DIFF
--- a/apps/app/Shared/AppDelegate.swift
+++ b/apps/app/Shared/AppDelegate.swift
@@ -67,6 +67,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        macMenuBar.showReader()
+        return false
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        macMenuBar.closeReaderForQuitShortcut() ? .terminateCancel : .terminateNow
+    }
+
     func application(
         _ application: NSApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data

--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -45,6 +45,14 @@ enum AppRoute: Hashable {
     case settings
 }
 
+#if os(macOS)
+enum ReaderPane: Hashable {
+    case inbox
+    case keys
+    case settings
+}
+#endif
+
 enum AppTab: Hashable {
     case inbox
     case keys
@@ -106,6 +114,22 @@ final class AppModel {
     }
     private(set) var keysAllowingAnyLink: Set<Int>
     var presentingCreateKey = false
+    #if os(macOS)
+    var readerSelection: Int?
+    var readerSelected: Set<Int> = []
+    var readerCursor: Int?
+    var readerConfirmingDelete = false
+    var readerPane: ReaderPane = .inbox
+    var readerKeysPath: [CachedKey] = []
+    var readerPresentingCreateKey = false
+
+    func readerSelect(_ serverID: Int) {
+        readerPane = .inbox
+        readerSelection = serverID
+        readerCursor = serverID
+        readerSelected = [serverID]
+    }
+    #endif
 
     private(set) var identity: DeviceIdentity?
     private(set) var api: APIClient?
@@ -421,9 +445,38 @@ final class AppModel {
             path.append(serverID)
             sync?.reconcileNotifications()
             #if os(macOS)
+            readerSelect(serverID)
             NotificationCenter.default.post(name: .notifiOpenPanel, object: nil)
             #endif
         }
+    }
+
+    func markRead(serverIDs: Set<Int>) {
+        guard let context else { return }
+        let ids = Array(serverIDs)
+        let descriptor = FetchDescriptor<Message>(predicate: #Predicate { ids.contains($0.serverID) })
+        guard let messages = try? context.fetch(descriptor) else { return }
+        for message in messages where !message.isRead { message.isRead = true }
+        do {
+            try context.save()
+        } catch {
+            log.error("mark read failed: \(String(describing: error), privacy: .private)")
+        }
+        sync?.reconcileNotifications()
+    }
+
+    func delete(serverIDs: Set<Int>) {
+        guard let context else { return }
+        let ids = Array(serverIDs)
+        let descriptor = FetchDescriptor<Message>(predicate: #Predicate { ids.contains($0.serverID) })
+        guard let messages = try? context.fetch(descriptor) else { return }
+        for message in messages { context.delete(message) }
+        do {
+            try context.save()
+        } catch {
+            log.error("delete failed: \(String(describing: error), privacy: .private)")
+        }
+        sync?.reconcileNotifications()
     }
 
     func markRead(serverID: Int) {

--- a/apps/app/Shared/MacMenuBar.swift
+++ b/apps/app/Shared/MacMenuBar.swift
@@ -10,6 +10,7 @@ final class MenuBarController: NSObject {
     private var animator: BellAnimator?
     private var model: AppModel?
     private var container: ModelContainer?
+    private let reader = ReaderWindowController()
 
     private let panelSize = NSSize(width: 460, height: 700)
 
@@ -30,6 +31,7 @@ final class MenuBarController: NSObject {
     func configure(model: AppModel, container: ModelContainer) {
         self.model = model
         self.container = container
+        reader.configure(model: model, container: container)
 
         popover.behavior = ProcessInfo.processInfo.environment["NOTIFI_STICKY"] == nil
             ? .transient
@@ -52,6 +54,7 @@ final class MenuBarController: NSObject {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         item.button?.target = self
         item.button?.action = #selector(togglePanel(_:))
+        item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
         statusItem = item
 
         NotificationCenter.default.addObserver(
@@ -72,6 +75,26 @@ final class MenuBarController: NSObject {
         )
 
         render(angle: 0)
+
+        #if DEBUG
+        if ProcessInfo.processInfo.environment["NOTIFI_OPEN_READER"] == "1" {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in self?.showReader() }
+        }
+        #endif
+    }
+
+    func showReader() {
+        if popover.isShown { popover.performClose(nil) }
+        reader.show()
+    }
+
+    func closeReaderForQuitShortcut() -> Bool {
+        guard reader.isKey, let event = NSApp.currentEvent, event.type == .keyDown,
+              event.modifierFlags.contains(.command),
+              event.charactersIgnoringModifiers?.lowercased() == "q"
+        else { return false }
+        reader.close()
+        return true
     }
 
     private var hasUnread: Bool { model?.hasUnread ?? false }
@@ -111,11 +134,24 @@ final class MenuBarController: NSObject {
     }
 
     @objc private func openPanel() {
+        if reader.isVisible {
+            reader.show()
+            return
+        }
         guard !popover.isShown, let button = statusItem?.button else { return }
         present(from: button)
     }
 
     @objc private func togglePanel(_ sender: Any?) {
+        if let event = NSApp.currentEvent,
+           event.type == .rightMouseUp || event.modifierFlags.contains(.option) {
+            showReader()
+            return
+        }
+        if reader.isOnScreen {
+            if !reader.isInFront { reader.show() }
+            return
+        }
         if popover.isShown {
             popover.performClose(sender)
             return

--- a/apps/app/Shared/MacReaderWindow.swift
+++ b/apps/app/Shared/MacReaderWindow.swift
@@ -1,0 +1,289 @@
+#if os(macOS)
+import AppKit
+import SwiftData
+import SwiftUI
+
+@MainActor
+final class ReaderWindowController: NSObject, NSWindowDelegate {
+    private var window: NSWindow?
+    private var model: AppModel?
+    private var container: ModelContainer?
+
+    private static let frameName = "reader"
+    private static let fullScreenKey = "readerFullScreen"
+
+    func configure(model: AppModel, container: ModelContainer) {
+        self.model = model
+        self.container = container
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(someWindowWillClose),
+            name: NSWindow.willCloseNotification, object: nil
+        )
+    }
+
+    var isVisible: Bool { window?.isVisible ?? false }
+
+    var isKey: Bool { window?.isKeyWindow ?? false }
+
+    var isOnScreen: Bool {
+        guard let window, window.isVisible, !window.isMiniaturized else { return false }
+        return true
+    }
+
+    var isInFront: Bool {
+        guard let window, isOnScreen, NSApp.isActive, window.isMainWindow else { return false }
+        return window.occlusionState.contains(.visible)
+    }
+
+    func close() { window?.performClose(nil) }
+
+    func show() {
+        guard let window = window ?? makeWindow() else { return }
+        NSApp.setActivationPolicy(.regular)
+        claimSettingsMenuItem()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        let wantsFullScreen = UserDefaults.standard.bool(forKey: Self.fullScreenKey)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+            if wantsFullScreen, !window.styleMask.contains(.fullScreen) {
+                window.toggleFullScreen(nil)
+            }
+        }
+    }
+
+    private func makeWindow() -> NSWindow? {
+        guard let model, let container else { return nil }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1100, height: 700),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered, defer: false
+        )
+        window.title = Copy.Push.fallbackTitle
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
+        window.isReleasedWhenClosed = false
+        window.minSize = NSSize(width: 880, height: 560)
+        window.collectionBehavior = [.fullScreenPrimary, .managed]
+        window.delegate = self
+
+        let root = ReaderView()
+            .environment(model)
+            .modelContainer(container)
+        let hosting = NSHostingController(rootView: root)
+        hosting.sizingOptions = []
+        window.contentViewController = hosting
+        window.setContentSize(NSSize(width: 1100, height: 700))
+
+        if !window.setFrameUsingName(Self.frameName) { window.center() }
+        window.setFrameAutosaveName(Self.frameName)
+        self.window = window
+        return window
+    }
+
+    private func claimSettingsMenuItem() {
+        guard let item = NSApp.mainMenu?.items.first?.submenu?.items.first(where: {
+            $0.keyEquivalent == "," && $0.keyEquivalentModifierMask == .command
+        }) else { return }
+        item.target = self
+        item.action = #selector(showSettingsPane)
+    }
+
+    @objc private func showSettingsPane() {
+        model?.readerPane = .settings
+        show()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard let window else { return }
+        UserDefaults.standard.set(window.styleMask.contains(.fullScreen), forKey: Self.fullScreenKey)
+    }
+
+    @objc private func someWindowWillClose(_ notification: Notification) {
+        DispatchQueue.main.async { [weak self] in self?.settleActivationPolicy() }
+    }
+
+    private func settleActivationPolicy() {
+        NSApp.setActivationPolicy(isVisible ? .regular : .accessory)
+    }
+}
+
+struct ReaderView: View {
+    @Environment(AppModel.self) private var model
+    @Query(sort: \Message.createdAt, order: .reverse) private var messages: [Message]
+    @AppStorage("readerSidebarWidth") private var sidebarWidth = 340.0
+
+    static let sidebarRange: ClosedRange<Double> = 320...440
+
+    var body: some View {
+        @Bindable var model = model
+        HStack(spacing: 0) {
+            InboxView()
+                .frame(width: min(max(sidebarWidth, Self.sidebarRange.lowerBound),
+                                  Self.sidebarRange.upperBound))
+            ReaderDivider(width: $sidebarWidth)
+            ReaderPaneView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .environment(\.contentMeasure, Theme.readerMeasure)
+        }
+        .environment(\.isReaderWindow, true)
+        .geistSurface(model)
+        .onAppear {
+            #if DEBUG
+            if SampleData.isEnabled, let index = SampleData.launchMessageIndex {
+                model.readerSelection = SampleData.serverID(at: index)
+            }
+            if AppTab.launchOverride == .keys { model.readerPane = .keys }
+            #endif
+            if model.readerSelection == nil { model.readerSelection = messages.first?.serverID }
+        }
+        .onChange(of: messages.count) {
+            let present = Set(messages.map(\.serverID))
+            model.readerSelected = model.readerSelected.intersection(present)
+            if let selected = model.readerSelection, !present.contains(selected) {
+                if let first = messages.first?.serverID { model.readerSelect(first) } else {
+                    model.readerSelection = nil
+                }
+            }
+        }
+        .alert(Copy.Reader.deleteSelectedTitle(Copy.Inbox.count(model.readerSelected.count)),
+               isPresented: $model.readerConfirmingDelete) {
+            Button(Copy.Common.delete, role: .destructive) { model.delete(serverIDs: model.readerSelected) }
+            Button(Copy.Common.cancel, role: .cancel) {}
+        } message: {
+            Text(Copy.Inbox.deleteMessage)
+        }
+    }
+}
+
+private struct ReaderDivider: View {
+    @Binding var width: Double
+    @State private var startWidth: Double?
+
+    var body: some View {
+        Rectangle()
+            .fill(Theme.chromeRuleColor)
+            .frame(width: Theme.chromeRule)
+            .ignoresSafeArea()
+            .contentShape(Rectangle().inset(by: -4))
+            .onHover { hovering in
+                if hovering { NSCursor.resizeLeftRight.push() } else { NSCursor.pop() }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 1, coordinateSpace: .global)
+                    .onChanged { value in
+                        let base = startWidth ?? width
+                        startWidth = base
+                        width = min(max(base + value.translation.width, ReaderView.sidebarRange.lowerBound),
+                                    ReaderView.sidebarRange.upperBound)
+                    }
+                    .onEnded { _ in startWidth = nil }
+            )
+    }
+}
+
+private struct ReaderPaneView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        @Bindable var model = model
+        Group {
+            switch model.readerPane {
+            case .inbox:
+                if let serverID = model.readerSelection {
+                    MessageDetailView(serverID: serverID).id(serverID)
+                } else {
+                    ReaderEmptyView()
+                }
+            case .keys:
+                NavigationStack(path: $model.readerKeysPath) { KeysView() }
+            case .settings:
+                NavigationStack { SettingsView() }
+            }
+        }
+        .overlay {
+            if model.readerPresentingCreateKey {
+                CreateKeyView { model.readerPresentingCreateKey = false }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Theme.bg)
+                    .transition(reduceMotion ? .opacity : .move(edge: .bottom))
+            }
+        }
+        .animation(.easeOut(duration: 0.2), value: model.readerPresentingCreateKey)
+    }
+}
+
+private struct ReaderEmptyView: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 14) {
+                Image("EmptyBell")
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 72, height: 72)
+                    .foregroundStyle(Theme.dim)
+                    .grainGlyph()
+                    .accessibilityHidden(true)
+                Text(Copy.Reader.selectPrompt)
+                    .font(Theme.body)
+                    .foregroundStyle(Theme.muted)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.bottom, Theme.gutter)
+        }
+        .background(StaticField())
+    }
+}
+
+struct ReaderSwitch: View {
+    @Environment(AppModel.self) private var model
+
+    var body: some View {
+        HStack(spacing: Theme.headerActionSpacing) {
+            ReaderSwitchButton(icon: "akar-key", label: Copy.Tabs.keys,
+                               isOn: model.readerPane == .keys) {
+                model.readerPane = model.readerPane == .keys ? .inbox : .keys
+            }
+            .keyboardShortcut("2", modifiers: .command)
+
+            ReaderSwitchButton(icon: "akar-gear", label: Copy.Tabs.settings,
+                               isOn: model.readerPane == .settings) {
+                model.readerPane = model.readerPane == .settings ? .inbox : .settings
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
+    }
+}
+
+private struct ReaderSwitchButton: View {
+    let icon: String
+    let label: String
+    let isOn: Bool
+    let action: () -> Void
+
+    @ScaledMetric(relativeTo: .body) private var iconSize: CGFloat = 19
+    @ScaledMetric(relativeTo: .body) private var frameSize: CGFloat = 34
+
+    var body: some View {
+        Button(action: action) {
+            Image(icon)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: iconSize, height: iconSize)
+                .foregroundStyle(isOn ? Theme.brand : Theme.fg)
+                .frame(width: frameSize, height: frameSize)
+                .glassBackground(enabled: true)
+                .geistHitArea(expandedBy: 5)
+        }
+        .buttonStyle(.geist)
+        .help(label)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isOn ? [.isSelected] : [])
+    }
+}
+#endif

--- a/apps/app/Shared/NotifiApp.swift
+++ b/apps/app/Shared/NotifiApp.swift
@@ -96,12 +96,7 @@ struct RootContentView: View {
                 InboxRootView()
             }
         }
-        .tint(Theme.brand)
-        .font(.inco(.body))
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(StaticField())
-        .environment(\.grainEnabled, model.grainEnabled)
-        .preferredColorScheme(model.appearance.colorScheme)
+        .geistSurface(model)
         #if os(macOS)
         .overlay {
             if model.presentingCreateKey {

--- a/apps/app/Shared/Resources/Localizable.xcstrings
+++ b/apps/app/Shared/Resources/Localizable.xcstrings
@@ -6771,6 +6771,111 @@
         }
       }
     },
+    "reader.deleteSelectedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete %1$@?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar %1$@?"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ löschen?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer %1$@ ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminare %1$@?"
+          }
+        }
+      }
+    },
+    "reader.openInWindow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in window"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir en una ventana"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Fenster öffnen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir dans une fenêtre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri in una finestra"
+          }
+        }
+      }
+    },
+    "reader.selectPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a notification"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona una notificación"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle eine Benachrichtigung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez une notification"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona una notifica"
+          }
+        }
+      }
+    },
     "restore.detail": {
       "extractionState": "manual",
       "localizations": {

--- a/apps/app/Shared/Support/Copy.swift
+++ b/apps/app/Shared/Support/Copy.swift
@@ -71,6 +71,11 @@ enum Copy {
         static var deleteTitleFallback: String { NSLocalizedString("inbox.deleteTitleFallback", comment: "") }
         static var deleteMessage: String { NSLocalizedString("inbox.deleteMessage", comment: "") }
     }
+    enum Reader {
+        static var openInWindow: String { NSLocalizedString("reader.openInWindow", comment: "") }
+        static var selectPrompt: String { NSLocalizedString("reader.selectPrompt", comment: "") }
+        static func deleteSelectedTitle(_ count: String) -> String { String.localizedStringWithFormat(NSLocalizedString("reader.deleteSelectedTitle", comment: ""), count) }
+    }
     enum Search {
         static var prompt: String { NSLocalizedString("search.prompt", comment: "") }
         static func matches(_ n: Int) -> String { String.localizedStringWithFormat(NSLocalizedString("search.matches", comment: ""), n) }

--- a/apps/app/Shared/Support/Theme.swift
+++ b/apps/app/Shared/Support/Theme.swift
@@ -60,6 +60,8 @@ enum Theme {
 
     static let gutter: CGFloat = 20
 
+    static let readerMeasure: CGFloat = 640
+
     #if os(macOS)
     static let chromeRule: CGFloat = 3
     static let chromeRuleColor = fg
@@ -316,6 +318,45 @@ extension View {
 
 extension EnvironmentValues {
     @Entry var grainEnabled = true
+    @Entry var isReaderWindow = false
+    @Entry var contentMeasure: CGFloat? = nil
+}
+
+struct GeistMeasure: ViewModifier {
+    @Environment(\.contentMeasure) private var measure
+
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: measure ?? .infinity)
+            .frame(maxWidth: .infinity)
+    }
+}
+
+#if os(macOS)
+struct GeistBottomPlate: ViewModifier {
+    @Environment(\.isReaderWindow) private var isReader
+
+    func body(content: Content) -> some View {
+        content.contentMargins(.bottom, isReader ? Theme.gutter : Theme.bottomPlate, for: .scrollContent)
+    }
+}
+#endif
+
+extension View {
+    func geistMeasure() -> some View { modifier(GeistMeasure()) }
+
+    #if os(macOS)
+    func geistBottomPlate() -> some View { modifier(GeistBottomPlate()) }
+    #endif
+
+    func geistSurface(_ model: AppModel) -> some View {
+        tint(Theme.brand)
+            .font(.inco(.body))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(StaticField())
+            .environment(\.grainEnabled, model.grainEnabled)
+            .preferredColorScheme(model.appearance.colorScheme)
+    }
 }
 
 struct GrainGlyph: ViewModifier {

--- a/apps/app/Shared/Views/Components/FeedHeader.swift
+++ b/apps/app/Shared/Views/Components/FeedHeader.swift
@@ -6,6 +6,9 @@ struct FeedHeader<Trailing: View, Accessory: View>: View {
     @Environment(AppModel.self) private var model
     @Environment(\.modelContext) private var context
     @Query(sort: \Message.createdAt, order: .reverse) private var messages: [Message]
+    #if os(macOS)
+    @Environment(\.isReaderWindow) private var isReader
+    #endif
 
     var title: String = Copy.Inbox.title
     var subtitle: Text? = nil
@@ -70,10 +73,16 @@ struct FeedHeader<Trailing: View, Accessory: View>: View {
 
             #if os(macOS)
             Divider()
+            if !isReader {
+                Button(Copy.Reader.openInWindow) { macMenuBar.showReader() }
+                    .keyboardShortcut("o", modifiers: [.command, .shift])
+            }
             Button(Copy.Inbox.refresh) { Task { await model.refresh() } }
                 .keyboardShortcut("r", modifiers: .command)
-            Button(Copy.Common.quit) { NSApplication.shared.terminate(nil) }
-                .keyboardShortcut("q", modifiers: .command)
+            if !isReader {
+                Button(Copy.Common.quit) { NSApplication.shared.terminate(nil) }
+                    .keyboardShortcut("q", modifiers: .command)
+            }
             #endif
 
             #if DEBUG

--- a/apps/app/Shared/Views/Components/GeistComponents.swift
+++ b/apps/app/Shared/Views/Components/GeistComponents.swift
@@ -182,12 +182,26 @@ struct IconButton: View {
     }
 }
 
+#if os(macOS)
+private struct GlassHover: ViewModifier {
+    let shape: AnyShape
+    @State private var hovering = false
+
+    func body(content: Content) -> some View {
+        content
+            .background(shape.fill(Theme.chip.opacity(hovering ? 1 : 0.6)))
+            .animation(Theme.press, value: hovering)
+            .onHover { hovering = $0 }
+    }
+}
+#endif
+
 extension View {
     @ViewBuilder
     func glassBackground(enabled: Bool = true, in shape: some Shape = Circle()) -> some View {
         if enabled {
             #if os(macOS)
-            background(shape.fill(Theme.chip.opacity(0.6)))
+            modifier(GlassHover(shape: AnyShape(shape)))
             #else
             if #available(iOS 26.0, *) {
                 glassEffect(.regular, in: shape)

--- a/apps/app/Shared/Views/Components/GeistPage.swift
+++ b/apps/app/Shared/Views/Components/GeistPage.swift
@@ -23,6 +23,7 @@ struct GeistPage<Header: View, Content: View>: View {
             header()
                 .geistPageHeader()
                 .geistGutter()
+                .geistMeasure()
                 .background(StaticField())
 
             scrollingContent
@@ -41,11 +42,12 @@ struct GeistPage<Header: View, Content: View>: View {
         case .page:
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) { content() }
+                    .geistMeasure()
             }
             .scrollContentBackground(.hidden)
             .contentMargins(.top, Theme.contentTop, for: .scrollContent)
             #if os(macOS)
-            .contentMargins(.bottom, Theme.bottomPlate, for: .scrollContent)
+            .geistBottomPlate()
             #endif
             .geistTopFade()
         }

--- a/apps/app/Shared/Views/Components/MessageFeed.swift
+++ b/apps/app/Shared/Views/Components/MessageFeed.swift
@@ -13,6 +13,10 @@ struct MessageFeed<Empty: View>: View {
 
     @State private var now = Date()
     @State private var pendingDelete: Message?
+    #if os(macOS)
+    @Environment(\.isReaderWindow) private var isReader
+    @FocusState private var feedFocused: Bool
+    #endif
 
     private var clock: AnyPublisher<Date, Never> {
         Timer.publish(every: 30, tolerance: 5, on: .main, in: .common)
@@ -45,10 +49,97 @@ struct MessageFeed<Empty: View>: View {
     @ViewBuilder
     private var feed: some View {
         #if os(macOS)
-        ScrollView { LazyVStack(spacing: 0) { rows } }
+        ScrollViewReader { proxy in
+            ScrollView { LazyVStack(spacing: 0) { rows } }
+                .focusable(isReader)
+                .focusEffectDisabled()
+                .focused($feedFocused)
+                .onKeyPress(keys: [.downArrow]) { press in
+                    step(1, extending: press.modifiers.contains(.shift), proxy: proxy)
+                }
+                .onKeyPress(keys: [.upArrow]) { press in
+                    step(-1, extending: press.modifiers.contains(.shift), proxy: proxy)
+                }
+                .onKeyPress(keys: [.delete, KeyEquivalent("\u{8}")]) { press in
+                    press.modifiers.contains(.command) ? requestDelete() : .ignored
+                }
+        }
         #else
         List { rows }
         #endif
+    }
+
+    #if os(macOS)
+    private func step(_ delta: Int, extending: Bool, proxy: ScrollViewProxy) -> KeyPress.Result {
+        guard isReader, !messages.isEmpty else { return .ignored }
+        let from = extending ? model.readerCursor : model.readerSelection
+        let current = messages.firstIndex { $0.serverID == from }
+        let next = current.map { min(max($0 + delta, 0), messages.count - 1) } ?? 0
+        let target = messages[next].serverID
+        if extending, let anchor = model.readerSelection {
+            model.readerPane = .inbox
+            model.readerCursor = target
+            model.readerSelected = range(from: anchor, to: target)
+        } else {
+            model.readerSelect(target)
+        }
+        withAnimation(Theme.state) { proxy.scrollTo(target) }
+        return .handled
+    }
+
+    private func range(from anchor: Int, to cursor: Int) -> Set<Int> {
+        guard let a = messages.firstIndex(where: { $0.serverID == anchor }),
+              let b = messages.firstIndex(where: { $0.serverID == cursor }) else { return [cursor] }
+        return Set(messages[min(a, b)...max(a, b)].map(\.serverID))
+    }
+
+    private func requestDelete() -> KeyPress.Result {
+        guard isReader, model.readerPane == .inbox else { return .ignored }
+        if model.readerSelected.count > 1 {
+            model.readerConfirmingDelete = true
+        } else if let message = messages.first(where: { $0.serverID == model.readerSelection }) {
+            pendingDelete = message
+        } else {
+            return .ignored
+        }
+        return .handled
+    }
+
+    private func isSelected(_ message: Message) -> Bool {
+        isReader && model.readerPane == .inbox && model.readerSelected.contains(message.serverID)
+    }
+
+    private func isInBatch(_ message: Message) -> Bool {
+        isSelected(message) && model.readerSelected.count > 1
+    }
+    #endif
+
+    private func open(_ message: Message) {
+        #if os(macOS)
+        if isReader {
+            let flags = NSEvent.modifierFlags
+            let id = message.serverID
+            if flags.contains(.shift), let anchor = model.readerSelection {
+                model.readerPane = .inbox
+                model.readerCursor = id
+                model.readerSelected = range(from: anchor, to: id)
+            } else if flags.contains(.command), model.readerPane == .inbox {
+                var selected = model.readerSelected
+                if selected.contains(id) { selected.remove(id) } else { selected.insert(id) }
+                if selected.isEmpty { selected = [id] }
+                model.readerSelected = selected
+                model.readerCursor = id
+                if !selected.contains(model.readerSelection ?? -1) || selected.count == 1 {
+                    model.readerSelection = selected.count == 1 ? selected.first : id
+                }
+            } else {
+                model.readerSelect(id)
+            }
+            feedFocused = true
+            return
+        }
+        #endif
+        model.path.append(message.serverID)
     }
 
     var body: some View {
@@ -57,7 +148,7 @@ struct MessageFeed<Empty: View>: View {
         .environment(\.defaultMinListRowHeight, 0)
         .scrollContentBackground(.hidden)
         #if os(macOS)
-        .contentMargins(.bottom, Theme.bottomPlate, for: .scrollContent)
+        .geistBottomPlate()
         #endif
         .contentMargins(.top, Theme.listContentTop, for: .scrollContent)
         .geistTopFade()
@@ -89,13 +180,25 @@ struct MessageFeed<Empty: View>: View {
     @ViewBuilder
     private func row(for message: Message, showsRule: Bool) -> some View {
         Button {
-            model.path.append(message.serverID)
+            open(message)
         } label: {
             MessageRow(message: message, now: now,
                        showsRule: showsRule,
                        openLink: openAction(for: message))
                 .contentShape(Rectangle())
         }
+        #if os(macOS)
+        .background {
+            if isSelected(message) { StaticField(level: .raised, fillsScreen: false) }
+        }
+        .overlay(alignment: .leading) {
+            if isSelected(message) {
+                Rectangle().fill(Theme.brand).frame(width: Theme.chromeRule)
+                    .accessibilityHidden(true)
+            }
+        }
+        .id(message.serverID)
+        #endif
         .buttonStyle(.geistRow)
         .plainRow()
         #if os(iOS)
@@ -163,7 +266,15 @@ struct MessageFeed<Empty: View>: View {
             #endif
         }
         Divider()
+        #if os(macOS)
+        if isInBatch(message) {
+            Button(Copy.Common.delete, role: .destructive) { model.readerConfirmingDelete = true }
+        } else {
+            Button(Copy.Common.delete, role: .destructive) { pendingDelete = message }
+        }
+        #else
         Button(Copy.Common.delete, role: .destructive) { pendingDelete = message }
+        #endif
     }
 
     private func toggleRead(_ message: Message) {

--- a/apps/app/Shared/Views/CreateKeyView.swift
+++ b/apps/app/Shared/Views/CreateKeyView.swift
@@ -44,6 +44,7 @@ struct CreateKeyView: View {
             }
             .geistGutter()
             .padding(.bottom, 40)
+            .geistMeasure()
         }
         .background(Theme.bg)
         .scrollContentBackground(.hidden)

--- a/apps/app/Shared/Views/InboxView.swift
+++ b/apps/app/Shared/Views/InboxView.swift
@@ -19,6 +19,8 @@ struct InboxView: View {
     @FocusState private var searchFocused: Bool
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var sizeClass
+    #else
+    @Environment(\.isReaderWindow) private var isReader
     #endif
 
     private var keys: [CachedKey] { model.sync?.keys ?? [] }
@@ -115,6 +117,16 @@ struct InboxView: View {
     }
 
     #if os(macOS)
+    private var openWindowButton: some View {
+        IconButton(systemImage: "arrow.up.left.and.arrow.down.right",
+                   label: Copy.Reader.openInWindow,
+                   glass: true) {
+            macMenuBar.showReader()
+        }
+    }
+
+    private var searchShown: Bool { !messages.isEmpty && showingSearch }
+
     private var searchToggle: some View {
         IconButton(systemImage: showingSearch ? "xmark" : "magnifyingglass",
                    label: showingSearch ? Copy.Inbox.closeSearch : Copy.Common.search,
@@ -138,7 +150,7 @@ struct InboxView: View {
 
     private var hasHeaderControls: Bool {
         #if os(macOS)
-        !messages.isEmpty && showingSearch
+        searchShown
         #else
         false
         #endif
@@ -149,15 +161,18 @@ struct InboxView: View {
             FeedHeader(title: activeKeyName ?? Copy.Inbox.title,
                        filterKeyID: $filterKeyID) {
                 #if os(macOS)
+                if isReader { ReaderSwitch() }
                 if !messages.isEmpty { searchToggle }
+                if !isReader { openWindowButton }
                 #endif
             }
             .padding(.bottom, hasHeaderControls ? 14 : 0)
 
             #if os(macOS)
-            if !messages.isEmpty, showingSearch {
+            if searchShown {
                 SearchField(text: $searchText, focused: $searchFocused)
                     .onExitCommand { closeSearch() }
+                    .padding(.bottom, 10)
             }
             #endif
         }

--- a/apps/app/Shared/Views/KeyDetailView.swift
+++ b/apps/app/Shared/Views/KeyDetailView.swift
@@ -30,7 +30,7 @@ struct KeyDetailView: View {
     var body: some View {
         ScrollView {
             if let key {
-                content(for: key).geistGutter()
+                content(for: key).geistGutter().geistMeasure()
             } else {
                 VStack(spacing: 10) {
                     Text(Copy.KeyDetail.notFound)

--- a/apps/app/Shared/Views/KeysView.swift
+++ b/apps/app/Shared/Views/KeysView.swift
@@ -6,6 +6,9 @@ struct KeysView: View {
     @State private var showingCreate = false
     #endif
     @State private var hasLoaded = false
+    #if os(macOS)
+    @Environment(\.isReaderWindow) private var isReader
+    #endif
 
     private var keys: [CachedKey] { model.sync?.keys ?? [] }
     private var activeKeys: [CachedKey] { keys.filter { !$0.isRevoked } }
@@ -31,7 +34,11 @@ struct KeysView: View {
                     #if os(iOS)
                     showingCreate = true
                     #else
-                    model.presentingCreateKey = true
+                    if isReader {
+                        model.readerPresentingCreateKey = true
+                    } else {
+                        model.presentingCreateKey = true
+                    }
                     #endif
                 }
             }

--- a/apps/app/Shared/Views/MessageDetailView.swift
+++ b/apps/app/Shared/Views/MessageDetailView.swift
@@ -18,6 +18,8 @@ struct MessageDetailView: View {
     @Environment(\.dismiss) private var dismiss
     #if os(iOS)
     @Environment(\.requestReview) private var requestReview
+    #else
+    @Environment(\.isReaderWindow) private var isReader
     #endif
     @Query private var messages: [Message]
     private let log = Logger(subsystem: "it.notifi.app", category: "store")
@@ -97,6 +99,7 @@ struct MessageDetailView: View {
             if let message {
                 content(for: message)
                     .geistGutter()
+                    .geistMeasure()
             } else {
                 VStack(spacing: 10) {
                     Text(Copy.Message.notFound)
@@ -113,7 +116,7 @@ struct MessageDetailView: View {
         .scrollContentBackground(.hidden)
         .contentMargins(.top, Theme.contentTop, for: .scrollContent)
         #if os(macOS)
-        .contentMargins(.bottom, Theme.bottomPlate, for: .scrollContent)
+        .geistBottomPlate()
         #endif
         .geistTopFade()
     }
@@ -123,12 +126,12 @@ struct MessageDetailView: View {
         context.delete(message)
         try? context.save()
         model.sync?.reconcileNotifications()
-        if !model.path.isEmpty { model.path.removeLast() } else { dismiss() }
+        goBack()
     }
 
     private var backBar: some View {
         HStack(spacing: 7) {
-            backButton
+            if !isReaderSurface { backButton }
 
             Spacer(minLength: 8)
 
@@ -152,7 +155,7 @@ struct MessageDetailView: View {
                     }
 
                     IconButton(systemName: "trash", label: Copy.Common.delete) {
-                        confirmingDelete = true
+                        requestDelete()
                     }
 
                     MenuButton(systemName: "ellipsis", label: Copy.Common.moreActions) {
@@ -166,8 +169,43 @@ struct MessageDetailView: View {
         .background(StaticField())
     }
 
+    private var isReaderSurface: Bool {
+        #if os(macOS)
+        isReader
+        #else
+        false
+        #endif
+    }
+
+    private func requestDelete() {
+        #if os(macOS)
+        if isReader, model.readerSelected.count > 1 {
+            model.readerConfirmingDelete = true
+            return
+        }
+        #endif
+        confirmingDelete = true
+    }
+
     private func goBack() {
+        #if os(macOS)
+        if isReader {
+            model.readerSelection = nil
+            return
+        }
+        #endif
         if !model.path.isEmpty { model.path.removeLast() } else { dismiss() }
+    }
+
+    private func openKey(_ key: CachedKey) {
+        #if os(macOS)
+        if isReader {
+            model.readerKeysPath = [key]
+            model.readerPane = .keys
+            return
+        }
+        #endif
+        model.path.append(key)
     }
 
     private var backButton: some View {
@@ -317,7 +355,7 @@ struct MessageDetailView: View {
     private func tappableKey<Label: View>(_ message: Message,
                                           @ViewBuilder label: () -> Label) -> some View {
         if let key = key(for: message), let name = keyName(for: message) {
-            Button { model.path.append(key) } label: { label() }
+            Button { openKey(key) } label: { label() }
                 .buttonStyle(.geist)
                 .accessibilityLabel(Copy.Message.openKey(name))
         } else if let name = keyName(for: message) {

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -161,6 +161,12 @@ export const copy = {
     deleteMessage: 'This cannot be undone.',
   },
 
+  reader: {
+    openInWindow: 'Open in window',
+    selectPrompt: 'Select a notification',
+    deleteSelectedTitle: 'Delete {count}?',
+  },
+
   search: {
     prompt: 'Search inbox',
     matches: plural('1 match', '{n} matches'),

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -147,6 +147,10 @@ export const de: Translation = {
   'inbox.deleteTitleFallback': 'Diese Benachrichtigung löschen?',
   'inbox.deleteMessage': 'Das kann nicht rückgängig gemacht werden.',
 
+  'reader.openInWindow': 'Im Fenster öffnen',
+  'reader.selectPrompt': 'Wähle eine Benachrichtigung',
+  'reader.deleteSelectedTitle': '{count} löschen?',
+
   'search.prompt': 'Inbox durchsuchen',
   'search.matches': { one: '1 Treffer', other: '{n} Treffer' },
   'search.recent': 'Zuletzt',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -100,6 +100,10 @@ export const es: Translation = {
   'inbox.deleteTitleFallback': '¿Eliminar esta notificación?',
   'inbox.deleteMessage': 'Esto no se puede deshacer.',
 
+  'reader.openInWindow': 'Abrir en una ventana',
+  'reader.selectPrompt': 'Selecciona una notificación',
+  'reader.deleteSelectedTitle': '¿Eliminar {count}?',
+
   'search.prompt': 'Buscar en Inbox',
   'search.matches': { one: '1 coincidencia', other: '{n} coincidencias' },
   'search.recent': 'Recientes',

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -101,6 +101,10 @@ export const fr: Translation = {
   'inbox.deleteTitleFallback': 'Supprimer cette notification ?',
   'inbox.deleteMessage': 'Cette action est irréversible.',
 
+  'reader.openInWindow': 'Ouvrir dans une fenêtre',
+  'reader.selectPrompt': 'Sélectionnez une notification',
+  'reader.deleteSelectedTitle': 'Supprimer {count} ?',
+
   'search.prompt': 'Rechercher dans Inbox',
   'search.matches': { one: '1 résultat', other: '{n} résultats' },
   'search.recent': 'Récents',

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -100,6 +100,10 @@ export const it: Translation = {
   'inbox.deleteTitleFallback': 'Eliminare questa notifica?',
   'inbox.deleteMessage': "Questa azione non può essere annullata.",
 
+  'reader.openInWindow': 'Apri in una finestra',
+  'reader.selectPrompt': 'Seleziona una notifica',
+  'reader.deleteSelectedTitle': 'Eliminare {count}?',
+
   'search.prompt': 'Cerca in Inbox',
   'search.matches': { one: '1 risultato', other: '{n} risultati' },
   'search.recent': 'Recenti',


### PR DESCRIPTION
Adds a normal macOS window with the inbox as a sidebar and the selected notification in a reading pane, opened from the popover's new expand button, its overflow menu, a right-click on the bell, or a Dock click. Keys and Settings open inside the pane from two buttons beside the INBOX title, and ⌘, and the app menu's Settings item land there too, so nothing opens a second window. The app takes a regular activation policy while the window is open and returns to the menu bar on close; ⌘Q in the window closes it rather than quitting. Rows take shift and ⌘ selection and ⌘⌫ deletes the selection. Screenshots below are the window in both appearances, the Keys pane, and the popover with its new button.

![Reading window, dark](https://github.com/user-attachments/assets/35ca3205-8d7c-4018-94d6-4c6a7f98d91d)

![Reading window, light](https://github.com/user-attachments/assets/b30bca0e-637c-40df-bca7-ff899f7e9281)

![Keys in the pane](https://github.com/user-attachments/assets/97de16c7-ea96-4b50-ad9c-f0f3150ddb44)

![Popover with the expand button](https://github.com/user-attachments/assets/bf7d6577-2cb6-49b8-ae67-5cb973549d86)