### PR TITLE
Landing page: match the Mac desk to the phone frame's height

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -859,7 +859,7 @@ section{padding:clamp(48px,7vw,86px) 0}
 .sub-head .rule{flex:1}
 .app-two{
   display:grid;grid-template-columns:repeat(2,minmax(0,1fr));
-  gap:clamp(24px,4.5vw,56px);align-items:center;
+  gap:clamp(24px,4.5vw,56px);align-items:start;
 }
 .app-phone{margin:0;order:2}
 /* The frame copies the film's phone (viewBox 428x900): bezel 13/428, outer
@@ -877,8 +877,8 @@ section{padding:clamp(48px,7vw,86px) 0}
   font-family:var(--mono);font-size:12px;color:var(--dim);
   margin-top:10px;text-align:center;
 }
-.app-two .mac{width:100%;max-width:440px;margin:0 auto}
-.app-two .mac-shot{width:min(360px,92%)}
+.app-two .mac{width:100%;max-width:470px;margin:0 auto}
+.app-two .mac-shot{width:min(432px,92%)}
 .app-two .mac figcaption{margin-top:10px;text-align:center}
 
 /* ── the Mac, hanging from its menu bar ─────────────────────── */


### PR DESCRIPTION
The two shots under the film were centred in their grid row, so the shorter Mac figure floated below the phone's top. They now top-align, and the Mac figure is widened so its desk comes out the phone frame's height at desktop widths. Below 760px they stack and nothing changes.

![On the device, 1280px](https://github.com/user-attachments/assets/5a67ee20-c6da-4e3b-a718-b29bb14a5cb4)